### PR TITLE
決済・抄録・参加者限定ページの追加実装

### DIFF
--- a/about.html
+++ b/about.html
@@ -25,6 +25,15 @@
                         <a href="events/index.html" class="nav-link">イベント</a>
                     </li>
                     <li class="nav-item">
+                        <a href="registration/index.html" class="nav-link">参加登録</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="abstracts/index.html" class="nav-link">抄録投稿</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="members/index.html" class="nav-link">参加者専用</a>
+                    </li>
+                    <li class="nav-item">
                         <a href="contact.html" class="nav-link">お問い合わせ</a>
                     </li>
                 </ul>

--- a/abstracts/guidelines.html
+++ b/abstracts/guidelines.html
@@ -1,0 +1,213 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>投稿ガイドライン - テスト学会</title>
+    <link rel="stylesheet" href="../css/style.css">
+</head>
+<body>
+    <header>
+        <nav class="navbar">
+            <div class="nav-container">
+                <h1 class="nav-logo">テスト学会</h1>
+                <ul class="nav-menu">
+                    <li class="nav-item">
+                        <a href="../index.html" class="nav-link">ホーム</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="../about.html" class="nav-link">学会について</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="../news/index.html" class="nav-link">お知らせ</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="../events/index.html" class="nav-link">イベント</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="../registration/index.html" class="nav-link">参加登録</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="index.html" class="nav-link active">抄録投稿</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="../members/index.html" class="nav-link">参加者専用</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="../contact.html" class="nav-link">お問い合わせ</a>
+                    </li>
+                </ul>
+                <div class="hamburger">
+                    <span class="bar"></span>
+                    <span class="bar"></span>
+                    <span class="bar"></span>
+                </div>
+            </div>
+        </nav>
+    </header>
+
+    <div class="page-header">
+        <div class="container">
+            <h1>抄録投稿ガイドライン</h1>
+            <p>2025年度学術会議 抄録投稿要領</p>
+        </div>
+    </div>
+
+    <main class="content">
+        <div class="container">
+            <div class="back-link">
+                <a href="index.html">← 抄録投稿トップに戻る</a>
+            </div>
+
+            <section class="content-section">
+                <h2>1. 投稿資格</h2>
+                <ul>
+                    <li>発表者（筆頭著者）は本学会の正会員または学生会員である必要があります</li>
+                    <li>共著者に非会員を含むことは可能です</li>
+                    <li>投稿時点で会員登録が完了している必要があります</li>
+                </ul>
+            </section>
+
+            <section class="content-section">
+                <h2>2. 発表形式と抄録字数</h2>
+                <div class="guidelines-table">
+                    <table>
+                        <thead>
+                            <tr>
+                                <th>発表形式</th>
+                                <th>抄録字数</th>
+                                <th>発表時間</th>
+                                <th>採択予定件数</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td>口頭発表</td>
+                                <td>800字以内</td>
+                                <td>15分（質疑応答5分含む）</td>
+                                <td>約50件</td>
+                            </tr>
+                            <tr>
+                                <td>ポスター発表</td>
+                                <td>600字以内</td>
+                                <td>2時間展示</td>
+                                <td>約100件</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </section>
+
+            <section class="content-section">
+                <h2>3. 抄録の構成</h2>
+                <h3>必須項目</h3>
+                <ol>
+                    <li><strong>タイトル:</strong> 研究内容を適切に表現する簡潔なタイトル</li>
+                    <li><strong>著者名・所属:</strong> 発表者を筆頭とし、所属機関を明記</li>
+                    <li><strong>研究分野:</strong> 指定のカテゴリから選択</li>
+                    <li><strong>本文:</strong> 以下の構成で記述
+                        <ul>
+                            <li>研究の背景・目的</li>
+                            <li>研究方法</li>
+                            <li>結果・考察</li>
+                            <li>結論</li>
+                        </ul>
+                    </li>
+                </ol>
+            </section>
+
+            <section class="content-section">
+                <h2>4. 書式・フォーマット</h2>
+                <h3>文字・言語</h3>
+                <ul>
+                    <li>日本語または英語での投稿が可能</li>
+                    <li>日本語の場合：ひらがな、カタカナ、漢字、半角英数字</li>
+                    <li>英語の場合：Times New Roman相当のフォント</li>
+                </ul>
+
+                <h3>図表の取り扱い</h3>
+                <ul>
+                    <li>抄録には図表を含めることはできません</li>
+                    <li>必要に応じて文章で説明してください</li>
+                    <li>数式は可能な限り文章で表現してください</li>
+                </ul>
+
+                <h3>参考文献</h3>
+                <ul>
+                    <li>抄録では参考文献の記載は不要です</li>
+                    <li>必要に応じて口頭発表時に提示してください</li>
+                </ul>
+            </section>
+
+            <section class="content-section">
+                <h2>5. 投稿方法</h2>
+                <ol>
+                    <li>オンライン投稿システムを使用してください</li>
+                    <li>投稿前に必ず内容を確認してください</li>
+                    <li>投稿完了後、確認メールが送信されます</li>
+                    <li>投稿締切: <strong>2025年7月31日（木）23:59</strong></li>
+                </ol>
+            </section>
+
+            <section class="content-section">
+                <h2>6. 審査・採択</h2>
+                <h3>審査基準</h3>
+                <ul>
+                    <li>研究の新規性・独創性</li>
+                    <li>研究方法の妥当性</li>
+                    <li>結果の信頼性</li>
+                    <li>学術的意義</li>
+                    <li>抄録の明確性</li>
+                </ul>
+
+                <h3>結果通知</h3>
+                <ul>
+                    <li>採択結果は2025年8月末までにメールで通知します</li>
+                    <li>採択された場合、発表形式（口頭・ポスター）を併せて通知します</li>
+                    <li>審査結果に関する個別の問い合わせにはお答えできません</li>
+                </ul>
+            </section>
+
+            <section class="content-section">
+                <h2>7. 注意事項</h2>
+                <div class="notice-box">
+                    <ul>
+                        <li>投稿は1人1件までとします</li>
+                        <li>他学会等での発表済み・投稿済みの研究は投稿できません</li>
+                        <li>投稿された抄録の著作権は本学会に帰属します</li>
+                        <li>採択された場合、発表者は必ず学術会議に参加してください</li>
+                        <li>発表者が欠席する場合、代理発表者を立ててください</li>
+                        <li>抄録の修正は締切日まで可能です</li>
+                    </ul>
+                </div>
+            </section>
+
+            <section class="content-section">
+                <h2>8. 抄録記載例</h2>
+                <div class="example-box">
+                    <h4>タイトル例</h4>
+                    <p>「機械学習を用いた画像認識システムの性能向上に関する研究」</p>
+                    
+                    <h4>本文例（一部）</h4>
+                    <p>【背景・目的】近年、深層学習技術の発展により画像認識の精度が大幅に向上している。しかし、実用的なシステムにおいては処理速度と精度のバランスが重要な課題となっている。本研究では、新しいアーキテクチャを提案し、従来手法と比較してその有効性を検証することを目的とする。</p>
+                    
+                    <p>【方法】提案手法では、畳み込み層の構造を最適化し...（以下略）</p>
+                </div>
+            </section>
+
+            <div class="form-actions">
+                <a href="index.html" class="btn btn-secondary">戻る</a>
+                <a href="submit.html" class="btn btn-primary">抄録を投稿する</a>
+            </div>
+        </div>
+    </main>
+
+    <footer>
+        <div class="container">
+            <p>&copy; 2025 テスト学会. All rights reserved.</p>
+        </div>
+    </footer>
+
+    <script src="../js/script.js"></script>
+</body>
+</html>

--- a/abstracts/index.html
+++ b/abstracts/index.html
@@ -1,0 +1,157 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>抄録投稿 - テスト学会</title>
+    <link rel="stylesheet" href="../css/style.css">
+</head>
+<body>
+    <header>
+        <nav class="navbar">
+            <div class="nav-container">
+                <h1 class="nav-logo">テスト学会</h1>
+                <ul class="nav-menu">
+                    <li class="nav-item">
+                        <a href="../index.html" class="nav-link">ホーム</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="../about.html" class="nav-link">学会について</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="../news/index.html" class="nav-link">お知らせ</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="../events/index.html" class="nav-link">イベント</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="../registration/index.html" class="nav-link">参加登録</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="index.html" class="nav-link active">抄録投稿</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="../members/index.html" class="nav-link">参加者専用</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="../contact.html" class="nav-link">お問い合わせ</a>
+                    </li>
+                </ul>
+                <div class="hamburger">
+                    <span class="bar"></span>
+                    <span class="bar"></span>
+                    <span class="bar"></span>
+                </div>
+            </div>
+        </nav>
+    </header>
+
+    <div class="page-header">
+        <div class="container">
+            <h1>抄録投稿システム</h1>
+            <p>学術会議での発表抄録をオンラインで投稿できます</p>
+        </div>
+    </div>
+
+    <main class="content">
+        <div class="container">
+            <section class="content-section">
+                <div class="abstract-overview">
+                    <h2>2025年度学術会議 抄録募集</h2>
+                    <div class="deadline-banner">
+                        <h3>📅 投稿締切: 2025年7月31日（木）23:59</h3>
+                    </div>
+                    
+                    <div class="submission-info">
+                        <div class="info-grid">
+                            <div class="info-card">
+                                <h4>口頭発表</h4>
+                                <p><strong>発表時間:</strong> 15分（質疑応答5分含む）</p>
+                                <p><strong>採択件数:</strong> 約50件予定</p>
+                                <p><strong>抄録字数:</strong> 800字以内</p>
+                            </div>
+                            <div class="info-card">
+                                <h4>ポスター発表</h4>
+                                <p><strong>展示時間:</strong> 2時間</p>
+                                <p><strong>採択件数:</strong> 約100件予定</p>
+                                <p><strong>抄録字数:</strong> 600字以内</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <section class="content-section">
+                <h2>投稿の流れ</h2>
+                <div class="process-steps">
+                    <div class="step">
+                        <div class="step-number">1</div>
+                        <div class="step-content">
+                            <h4>投稿ガイドライン確認</h4>
+                            <p>抄録の書き方やフォーマットを確認してください</p>
+                            <a href="guidelines.html" class="btn btn-secondary">ガイドライン</a>
+                        </div>
+                    </div>
+                    <div class="step">
+                        <div class="step-number">2</div>
+                        <div class="step-content">
+                            <h4>抄録投稿</h4>
+                            <p>オンラインフォームから抄録を投稿してください</p>
+                            <a href="submit.html" class="btn btn-primary">投稿する</a>
+                        </div>
+                    </div>
+                    <div class="step">
+                        <div class="step-number">3</div>
+                        <div class="step-content">
+                            <h4>審査・結果通知</h4>
+                            <p>採択結果は8月末までにメールでお知らせします</p>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <section class="content-section">
+                <h2>重要事項</h2>
+                <div class="notice-box">
+                    <ul>
+                        <li><strong>投稿資格:</strong> 学会会員（発表者は会員である必要があります）</li>
+                        <li><strong>共著者:</strong> 共著者に非会員を含むことは可能です</li>
+                        <li><strong>発表言語:</strong> 日本語または英語</li>
+                        <li><strong>重複投稿:</strong> 他学会との重複投稿は禁止です</li>
+                        <li><strong>著作権:</strong> 投稿された抄録の著作権は学会に帰属します</li>
+                        <li><strong>参加登録:</strong> 採択された場合、発表者は会議への参加登録が必要です</li>
+                    </ul>
+                </div>
+            </section>
+
+            <section class="content-section">
+                <h2>研究分野カテゴリ</h2>
+                <div class="category-grid">
+                    <div class="category-item">基礎理論</div>
+                    <div class="category-item">応用研究</div>
+                    <div class="category-item">実験研究</div>
+                    <div class="category-item">データ分析</div>
+                    <div class="category-item">システム開発</div>
+                    <div class="category-item">教育・学習</div>
+                    <div class="category-item">産業応用</div>
+                    <div class="category-item">その他</div>
+                </div>
+            </section>
+
+            <section class="content-section">
+                <h2>お問い合わせ</h2>
+                <p>抄録投稿に関するご質問は、<a href="../contact.html">お問い合わせページ</a>からご連絡ください。</p>
+                <p><strong>抄録投稿専用メール:</strong> abstracts@test-society.jp</p>
+            </section>
+        </div>
+    </main>
+
+    <footer>
+        <div class="container">
+            <p>&copy; 2025 テスト学会. All rights reserved.</p>
+        </div>
+    </footer>
+
+    <script src="../js/script.js"></script>
+</body>
+</html>

--- a/abstracts/submit.html
+++ b/abstracts/submit.html
@@ -1,0 +1,410 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>抄録投稿フォーム - テスト学会</title>
+    <link rel="stylesheet" href="../css/style.css">
+</head>
+<body>
+    <header>
+        <nav class="navbar">
+            <div class="nav-container">
+                <h1 class="nav-logo">テスト学会</h1>
+                <ul class="nav-menu">
+                    <li class="nav-item">
+                        <a href="../index.html" class="nav-link">ホーム</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="../about.html" class="nav-link">学会について</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="../news/index.html" class="nav-link">お知らせ</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="../events/index.html" class="nav-link">イベント</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="../registration/index.html" class="nav-link">参加登録</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="index.html" class="nav-link active">抄録投稿</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="../members/index.html" class="nav-link">参加者専用</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="../contact.html" class="nav-link">お問い合わせ</a>
+                    </li>
+                </ul>
+                <div class="hamburger">
+                    <span class="bar"></span>
+                    <span class="bar"></span>
+                    <span class="bar"></span>
+                </div>
+            </div>
+        </nav>
+    </header>
+
+    <div class="page-header">
+        <div class="container">
+            <h1>抄録投稿フォーム</h1>
+            <p>2025年度学術会議への抄録投稿</p>
+        </div>
+    </div>
+
+    <main class="content">
+        <div class="container">
+            <div class="back-link">
+                <a href="index.html">← 抄録投稿トップに戻る</a>
+            </div>
+
+            <div class="deadline-reminder">
+                <h3>📅 投稿締切: 2025年7月31日（木）23:59</h3>
+                <p><a href="guidelines.html" target="_blank">投稿ガイドライン</a>を必ずご確認ください</p>
+            </div>
+
+            <form class="abstract-form" id="abstractForm">
+                <div class="form-section">
+                    <h2>発表者情報</h2>
+                    
+                    <div class="form-row">
+                        <div class="form-group">
+                            <label for="presenterLastName">発表者 姓 *</label>
+                            <input type="text" id="presenterLastName" name="presenterLastName" required>
+                        </div>
+                        <div class="form-group">
+                            <label for="presenterFirstName">発表者 名 *</label>
+                            <input type="text" id="presenterFirstName" name="presenterFirstName" required>
+                        </div>
+                    </div>
+
+                    <div class="form-group">
+                        <label for="presenterEmail">発表者メールアドレス *</label>
+                        <input type="email" id="presenterEmail" name="presenterEmail" required>
+                    </div>
+
+                    <div class="form-group">
+                        <label for="presenterAffiliation">発表者所属 *</label>
+                        <input type="text" id="presenterAffiliation" name="presenterAffiliation" required placeholder="例：○○大学大学院 ○○研究科">
+                    </div>
+
+                    <div class="form-group">
+                        <label for="membershipNumber">会員番号 *</label>
+                        <input type="text" id="membershipNumber" name="membershipNumber" required placeholder="例：REG12345678">
+                        <small>学会会員番号を入力してください</small>
+                    </div>
+                </div>
+
+                <div class="form-section">
+                    <h2>共著者情報</h2>
+                    <p>共著者がいる場合は入力してください（最大5名まで）</p>
+                    
+                    <div id="coauthorsContainer">
+                        <div class="coauthor-item">
+                            <h4>共著者1</h4>
+                            <div class="form-row">
+                                <div class="form-group">
+                                    <label for="coauthor1LastName">姓</label>
+                                    <input type="text" id="coauthor1LastName" name="coauthor1LastName">
+                                </div>
+                                <div class="form-group">
+                                    <label for="coauthor1FirstName">名</label>
+                                    <input type="text" id="coauthor1FirstName" name="coauthor1FirstName">
+                                </div>
+                            </div>
+                            <div class="form-group">
+                                <label for="coauthor1Affiliation">所属</label>
+                                <input type="text" id="coauthor1Affiliation" name="coauthor1Affiliation">
+                            </div>
+                        </div>
+                    </div>
+
+                    <button type="button" class="btn btn-secondary" id="addCoauthor">共著者を追加</button>
+                </div>
+
+                <div class="form-section">
+                    <h2>研究内容</h2>
+                    
+                    <div class="form-group">
+                        <label for="title">研究タイトル *</label>
+                        <input type="text" id="title" name="title" required maxlength="100">
+                        <small><span id="titleCount">0</span>/100文字</small>
+                    </div>
+
+                    <div class="form-group">
+                        <label for="language">発表言語 *</label>
+                        <select id="language" name="language" required>
+                            <option value="">選択してください</option>
+                            <option value="japanese">日本語</option>
+                            <option value="english">英語</option>
+                        </select>
+                    </div>
+
+                    <div class="form-group">
+                        <label for="category">研究分野 *</label>
+                        <select id="category" name="category" required>
+                            <option value="">選択してください</option>
+                            <option value="fundamental">基礎理論</option>
+                            <option value="applied">応用研究</option>
+                            <option value="experimental">実験研究</option>
+                            <option value="data-analysis">データ分析</option>
+                            <option value="system">システム開発</option>
+                            <option value="education">教育・学習</option>
+                            <option value="industry">産業応用</option>
+                            <option value="other">その他</option>
+                        </select>
+                    </div>
+
+                    <div class="form-group">
+                        <label for="presentationType">希望発表形式 *</label>
+                        <div class="radio-group">
+                            <label class="radio-label">
+                                <input type="radio" name="presentationType" value="oral" required>
+                                <span class="radio-text">口頭発表（15分、抄録800字以内）</span>
+                            </label>
+                            <label class="radio-label">
+                                <input type="radio" name="presentationType" value="poster" required>
+                                <span class="radio-text">ポスター発表（2時間展示、抄録600字以内）</span>
+                            </label>
+                        </div>
+                        <small>最終的な発表形式は審査結果と併せて通知いたします</small>
+                    </div>
+                </div>
+
+                <div class="form-section">
+                    <h2>抄録本文</h2>
+                    
+                    <div class="form-group">
+                        <label for="abstract">抄録 *</label>
+                        <textarea id="abstract" name="abstract" required rows="15" placeholder="【背景・目的】
+研究の背景と目的を記述してください。
+
+【方法】
+研究方法を記述してください。
+
+【結果・考察】
+結果と考察を記述してください。
+
+【結論】
+結論を記述してください。"></textarea>
+                        <div class="character-count">
+                            <span id="abstractCount">0</span>/<span id="maxChars">800</span>文字
+                            <span id="charWarning" class="warning" style="display: none;">字数制限を超えています</span>
+                        </div>
+                    </div>
+
+                    <div class="form-group">
+                        <label for="keywords">キーワード</label>
+                        <input type="text" id="keywords" name="keywords" placeholder="キーワード1, キーワード2, キーワード3" maxlength="100">
+                        <small>カンマ区切りで3-5個程度入力してください</small>
+                    </div>
+                </div>
+
+                <div class="form-section">
+                    <h2>確認事項</h2>
+                    
+                    <div class="checkbox-group">
+                        <label class="checkbox-label">
+                            <input type="checkbox" name="agreement1" required>
+                            <span class="checkbox-text">発表者は本学会の会員であることを確認しました</span>
+                        </label>
+                        <label class="checkbox-label">
+                            <input type="checkbox" name="agreement2" required>
+                            <span class="checkbox-text">他学会等での発表済み・投稿済みの研究ではないことを確認しました</span>
+                        </label>
+                        <label class="checkbox-label">
+                            <input type="checkbox" name="agreement3" required>
+                            <span class="checkbox-text">投稿ガイドラインを確認し、規定に従って作成しました</span>
+                        </label>
+                        <label class="checkbox-label">
+                            <input type="checkbox" name="agreement4" required>
+                            <span class="checkbox-text">採択された場合は必ず学術会議に参加します</span>
+                        </label>
+                    </div>
+                </div>
+
+                <div class="form-actions">
+                    <button type="button" class="btn btn-secondary" onclick="window.history.back()">戻る</button>
+                    <button type="button" class="btn btn-secondary" id="saveAsDraft">下書き保存</button>
+                    <button type="submit" class="btn btn-primary">投稿する</button>
+                </div>
+            </form>
+
+            <div id="submitSuccess" class="success-message" style="display: none;">
+                <h2>✅ 抄録投稿が完了しました</h2>
+                <p>投稿ありがとうございます。確認メールをお送りしました。</p>
+                <div class="submission-number">
+                    <p><strong>投稿番号:</strong> <span id="submissionNumber"></span></p>
+                </div>
+                <div class="next-steps">
+                    <h3>今後の流れ</h3>
+                    <ul>
+                        <li>投稿番号をお控えください</li>
+                        <li>採択結果は8月末までにメールでお知らせします</li>
+                        <li>投稿内容の修正は締切日まで可能です</li>
+                    </ul>
+                </div>
+                <div class="form-actions">
+                    <a href="../index.html" class="btn btn-primary">ホームに戻る</a>
+                    <a href="index.html" class="btn btn-secondary">抄録投稿トップへ</a>
+                </div>
+            </div>
+        </div>
+    </main>
+
+    <footer>
+        <div class="container">
+            <p>&copy; 2025 テスト学会. All rights reserved.</p>
+        </div>
+    </footer>
+
+    <script src="../js/script.js"></script>
+    <script>
+        let coauthorCount = 1;
+        const maxCoauthors = 5;
+
+        // 文字数カウント
+        function updateCharacterCount() {
+            const abstractText = document.getElementById('abstract').value;
+            const presentationType = document.querySelector('input[name="presentationType"]:checked');
+            const maxChars = presentationType && presentationType.value === 'poster' ? 600 : 800;
+            
+            document.getElementById('maxChars').textContent = maxChars;
+            document.getElementById('abstractCount').textContent = abstractText.length;
+            
+            const warning = document.getElementById('charWarning');
+            if (abstractText.length > maxChars) {
+                warning.style.display = 'inline';
+            } else {
+                warning.style.display = 'none';
+            }
+        }
+
+        // タイトル文字数カウント
+        function updateTitleCount() {
+            const titleText = document.getElementById('title').value;
+            document.getElementById('titleCount').textContent = titleText.length;
+        }
+
+        // 共著者追加
+        function addCoauthor() {
+            if (coauthorCount >= maxCoauthors) {
+                alert('共著者は最大5名まで追加できます。');
+                return;
+            }
+            
+            coauthorCount++;
+            const container = document.getElementById('coauthorsContainer');
+            const coauthorDiv = document.createElement('div');
+            coauthorDiv.className = 'coauthor-item';
+            coauthorDiv.innerHTML = `
+                <h4>共著者${coauthorCount} <button type="button" class="btn-remove" onclick="removeCoauthor(this)">削除</button></h4>
+                <div class="form-row">
+                    <div class="form-group">
+                        <label for="coauthor${coauthorCount}LastName">姓</label>
+                        <input type="text" id="coauthor${coauthorCount}LastName" name="coauthor${coauthorCount}LastName">
+                    </div>
+                    <div class="form-group">
+                        <label for="coauthor${coauthorCount}FirstName">名</label>
+                        <input type="text" id="coauthor${coauthorCount}FirstName" name="coauthor${coauthorCount}FirstName">
+                    </div>
+                </div>
+                <div class="form-group">
+                    <label for="coauthor${coauthorCount}Affiliation">所属</label>
+                    <input type="text" id="coauthor${coauthorCount}Affiliation" name="coauthor${coauthorCount}Affiliation">
+                </div>
+            `;
+            container.appendChild(coauthorDiv);
+            
+            if (coauthorCount >= maxCoauthors) {
+                document.getElementById('addCoauthor').style.display = 'none';
+            }
+        }
+
+        function removeCoauthor(button) {
+            button.parentElement.parentElement.remove();
+            coauthorCount--;
+            document.getElementById('addCoauthor').style.display = 'inline-block';
+        }
+
+        // イベントリスナー
+        document.getElementById('abstract').addEventListener('input', updateCharacterCount);
+        document.getElementById('title').addEventListener('input', updateTitleCount);
+        document.getElementById('addCoauthor').addEventListener('click', addCoauthor);
+        
+        document.querySelectorAll('input[name="presentationType"]').forEach(input => {
+            input.addEventListener('change', updateCharacterCount);
+        });
+
+        // 下書き保存
+        document.getElementById('saveAsDraft').addEventListener('click', function() {
+            const formData = new FormData(document.getElementById('abstractForm'));
+            const data = {};
+            for (let [key, value] of formData.entries()) {
+                data[key] = value;
+            }
+            localStorage.setItem('abstractDraft', JSON.stringify(data));
+            alert('下書きを保存しました。');
+        });
+
+        // 下書き読み込み
+        function loadDraft() {
+            const draft = localStorage.getItem('abstractDraft');
+            if (draft && confirm('保存された下書きがあります。読み込みますか？')) {
+                const data = JSON.parse(draft);
+                for (let key in data) {
+                    const element = document.querySelector(`[name="${key}"]`);
+                    if (element) {
+                        if (element.type === 'radio' || element.type === 'checkbox') {
+                            if (element.value === data[key]) {
+                                element.checked = true;
+                            }
+                        } else {
+                            element.value = data[key];
+                        }
+                    }
+                }
+                updateCharacterCount();
+                updateTitleCount();
+            }
+        }
+
+        // フォーム送信
+        document.getElementById('abstractForm').addEventListener('submit', function(e) {
+            e.preventDefault();
+            
+            // 文字数チェック
+            const abstractText = document.getElementById('abstract').value;
+            const presentationType = document.querySelector('input[name="presentationType"]:checked');
+            const maxChars = presentationType.value === 'poster' ? 600 : 800;
+            
+            if (abstractText.length > maxChars) {
+                alert(`抄録の文字数が制限を超えています。${maxChars}字以内に収めてください。`);
+                return;
+            }
+            
+            // 投稿処理のシミュレーション
+            const submissionNumber = 'ABS' + Date.now().toString().slice(-8);
+            document.getElementById('submissionNumber').textContent = submissionNumber;
+            
+            // フォームを非表示にして成功メッセージを表示
+            document.getElementById('abstractForm').style.display = 'none';
+            document.getElementById('submitSuccess').style.display = 'block';
+            
+            // 下書きを削除
+            localStorage.removeItem('abstractDraft');
+            
+            // ページトップにスクロール
+            window.scrollTo(0, 0);
+        });
+
+        // ページ読み込み時の処理
+        document.addEventListener('DOMContentLoaded', function() {
+            loadDraft();
+            updateCharacterCount();
+            updateTitleCount();
+        });
+    </script>
+</body>
+</html>

--- a/contact.html
+++ b/contact.html
@@ -25,6 +25,15 @@
                         <a href="events/index.html" class="nav-link">イベント</a>
                     </li>
                     <li class="nav-item">
+                        <a href="registration/index.html" class="nav-link">参加登録</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="abstracts/index.html" class="nav-link">抄録投稿</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="members/index.html" class="nav-link">参加者専用</a>
+                    </li>
+                    <li class="nav-item">
                         <a href="contact.html" class="nav-link active">お問い合わせ</a>
                     </li>
                 </ul>

--- a/css/style.css
+++ b/css/style.css
@@ -346,6 +346,773 @@ footer {
     resize: vertical;
 }
 
+/* Registration and Abstract Submission Styles */
+.registration-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
+    gap: 2rem;
+    margin-bottom: 2rem;
+}
+
+.registration-card {
+    background: white;
+    border-radius: 8px;
+    padding: 2rem;
+    box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+    border-left: 4px solid #3498db;
+}
+
+.registration-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    margin-bottom: 1rem;
+}
+
+.registration-status {
+    padding: 0.25rem 0.75rem;
+    border-radius: 20px;
+    font-size: 0.8rem;
+    font-weight: bold;
+}
+
+.registration-status.available {
+    background-color: #d4edda;
+    color: #155724;
+}
+
+.registration-details {
+    margin-bottom: 1.5rem;
+}
+
+.registration-details ul {
+    margin-left: 1rem;
+    margin-top: 0.5rem;
+}
+
+.registration-actions {
+    text-align: center;
+}
+
+/* Form Styles */
+.registration-form, .abstract-form {
+    max-width: 800px;
+    margin: 0 auto;
+    background: white;
+    padding: 2rem;
+    border-radius: 8px;
+    box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+}
+
+.form-section {
+    margin-bottom: 2rem;
+    padding-bottom: 2rem;
+    border-bottom: 1px solid #eee;
+}
+
+.form-section:last-child {
+    border-bottom: none;
+}
+
+.form-section h2 {
+    font-size: 1.3rem;
+    margin-bottom: 1rem;
+    color: #2c3e50;
+    text-align: left;
+}
+
+.form-row {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1rem;
+}
+
+.radio-group, .checkbox-group {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.radio-label, .checkbox-label {
+    display: flex;
+    align-items: center;
+    cursor: pointer;
+    padding: 0.5rem;
+    border-radius: 4px;
+    transition: background-color 0.3s ease;
+}
+
+.radio-label:hover, .checkbox-label:hover {
+    background-color: #f8f9fa;
+}
+
+.radio-label input, .checkbox-label input {
+    margin-right: 0.5rem;
+}
+
+.radio-text, .checkbox-text {
+    font-size: 0.95rem;
+}
+
+.total-amount, .total-display {
+    background: #f8f9fa;
+    padding: 1rem;
+    border-radius: 8px;
+    text-align: center;
+    margin: 1rem 0;
+    border: 2px solid #3498db;
+}
+
+.character-count {
+    text-align: right;
+    font-size: 0.9rem;
+    color: #666;
+    margin-top: 0.5rem;
+}
+
+.warning {
+    color: #e74c3c;
+    font-weight: bold;
+}
+
+/* Payment Styles */
+.payment-container {
+    max-width: 900px;
+    margin: 0 auto;
+}
+
+.payment-summary {
+    background: white;
+    padding: 2rem;
+    border-radius: 8px;
+    box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+    margin-bottom: 2rem;
+}
+
+.payment-form {
+    background: white;
+    padding: 2rem;
+    border-radius: 8px;
+    box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+}
+
+.payment-method-section {
+    margin: 1rem 0;
+    padding: 1rem;
+    border: 1px solid #ddd;
+    border-radius: 8px;
+}
+
+.bank-info {
+    background: #f8f9fa;
+    padding: 1rem;
+    border-radius: 4px;
+    margin: 1rem 0;
+}
+
+.payment-complete {
+    text-align: center;
+    background: white;
+    padding: 3rem;
+    border-radius: 8px;
+    box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+}
+
+.success-message h2 {
+    color: #27ae60;
+    margin-bottom: 1rem;
+}
+
+.registration-number {
+    background: #e8f5e8;
+    padding: 1rem;
+    border-radius: 8px;
+    margin: 1rem 0;
+    border-left: 4px solid #27ae60;
+}
+
+/* Abstract Submission Styles */
+.deadline-banner {
+    background: linear-gradient(135deg, #e74c3c, #c0392b);
+    color: white;
+    padding: 1.5rem;
+    border-radius: 8px;
+    text-align: center;
+    margin: 2rem 0;
+}
+
+.deadline-reminder {
+    background: #fff3cd;
+    border: 1px solid #ffeaa7;
+    padding: 1rem;
+    border-radius: 8px;
+    margin-bottom: 2rem;
+}
+
+.info-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: 1.5rem;
+    margin: 2rem 0;
+}
+
+.info-card {
+    background: white;
+    padding: 1.5rem;
+    border-radius: 8px;
+    box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+    text-align: center;
+}
+
+.process-steps {
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+    margin: 2rem 0;
+}
+
+.step {
+    display: flex;
+    align-items: flex-start;
+    gap: 1.5rem;
+    padding: 1.5rem;
+    background: white;
+    border-radius: 8px;
+    box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+}
+
+.step-number {
+    background: #3498db;
+    color: white;
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: bold;
+    flex-shrink: 0;
+}
+
+.step-content h4 {
+    margin-bottom: 0.5rem;
+    color: #2c3e50;
+}
+
+.category-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: 1rem;
+    margin: 1rem 0;
+}
+
+.category-item {
+    background: #f8f9fa;
+    padding: 0.75rem;
+    border-radius: 8px;
+    text-align: center;
+    border: 2px solid transparent;
+    transition: all 0.3s ease;
+}
+
+.category-item:hover {
+    border-color: #3498db;
+    background-color: #e3f2fd;
+}
+
+.coauthor-item {
+    border: 1px solid #ddd;
+    padding: 1rem;
+    border-radius: 8px;
+    margin-bottom: 1rem;
+    background: #f9f9f9;
+}
+
+.btn-remove {
+    background: #e74c3c;
+    color: white;
+    border: none;
+    padding: 0.25rem 0.5rem;
+    border-radius: 4px;
+    font-size: 0.8rem;
+    cursor: pointer;
+    margin-left: 1rem;
+}
+
+.guidelines-table table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 1rem 0;
+}
+
+.guidelines-table th,
+.guidelines-table td {
+    padding: 0.75rem;
+    text-align: left;
+    border-bottom: 1px solid #ddd;
+}
+
+.guidelines-table th {
+    background-color: #f8f9fa;
+    font-weight: bold;
+}
+
+.example-box {
+    background: #f8f9fa;
+    padding: 1.5rem;
+    border-radius: 8px;
+    border-left: 4px solid #3498db;
+    margin: 1rem 0;
+}
+
+/* Members Area Styles */
+.login-required-section {
+    text-align: center;
+    padding: 3rem 0;
+}
+
+.login-prompt {
+    background: white;
+    padding: 3rem;
+    border-radius: 8px;
+    box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+    margin-bottom: 3rem;
+}
+
+.lock-icon {
+    font-size: 3rem;
+    margin-bottom: 1rem;
+}
+
+.login-options {
+    display: flex;
+    gap: 1rem;
+    justify-content: center;
+    margin-top: 2rem;
+}
+
+.access-info {
+    background: white;
+    padding: 2rem;
+    border-radius: 8px;
+    box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+}
+
+.info-item {
+    padding: 1rem;
+}
+
+.info-item h4 {
+    margin-bottom: 0.5rem;
+    color: #2c3e50;
+}
+
+.login-container {
+    max-width: 500px;
+    margin: 0 auto;
+}
+
+.login-form {
+    background: white;
+    padding: 2rem;
+    border-radius: 8px;
+    box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+    margin-bottom: 2rem;
+}
+
+.login-help {
+    text-align: center;
+    margin-top: 1rem;
+}
+
+.login-help a {
+    color: #3498db;
+    text-decoration: none;
+}
+
+.demo-credentials {
+    background: #e8f5e8;
+    padding: 1.5rem;
+    border-radius: 8px;
+    border-left: 4px solid #27ae60;
+}
+
+.demo-info {
+    background: white;
+    padding: 1rem;
+    border-radius: 4px;
+    margin-top: 1rem;
+}
+
+/* Dashboard Styles */
+.header-actions {
+    margin-top: 1rem;
+}
+
+.dashboard-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
+    gap: 2rem;
+    margin-top: 2rem;
+}
+
+.dashboard-section {
+    background: white;
+    padding: 2rem;
+    border-radius: 8px;
+    box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+}
+
+.dashboard-section h2 {
+    font-size: 1.3rem;
+    margin-bottom: 1rem;
+    color: #2c3e50;
+    text-align: left;
+}
+
+.status-paid {
+    color: #27ae60;
+    font-weight: bold;
+}
+
+.card-actions {
+    margin-top: 1rem;
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+}
+
+.notifications {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.notification-item {
+    display: flex;
+    align-items: flex-start;
+    gap: 1rem;
+    padding: 1rem;
+    background: #f8f9fa;
+    border-radius: 8px;
+    cursor: pointer;
+    transition: background-color 0.3s ease;
+}
+
+.notification-item:hover {
+    background-color: #e9ecef;
+}
+
+.notification-item.new {
+    border-left: 4px solid #e74c3c;
+    background: #fff5f5;
+}
+
+.notification-icon {
+    font-size: 1.5rem;
+    flex-shrink: 0;
+}
+
+.notification-content h4 {
+    margin-bottom: 0.5rem;
+    color: #2c3e50;
+}
+
+.notification-date {
+    font-size: 0.8rem;
+    color: #666;
+}
+
+.qr-ticket {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1rem;
+    padding: 1.5rem;
+    background: #f8f9fa;
+    border-radius: 8px;
+    border: 2px dashed #3498db;
+}
+
+.qr-code {
+    width: 150px;
+    height: 150px;
+    background: white;
+    border: 2px solid #333;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: bold;
+    position: relative;
+}
+
+.qr-pattern {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    opacity: 0.1;
+    background: repeating-linear-gradient(0deg, #000, #000 2px, transparent 2px, transparent 4px),
+                repeating-linear-gradient(90deg, #000, #000 2px, transparent 2px, transparent 4px);
+}
+
+.ticket-info {
+    text-align: center;
+}
+
+.ticket-actions {
+    display: flex;
+    gap: 0.5rem;
+}
+
+.materials-list {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.material-item {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding: 1rem;
+    background: #f8f9fa;
+    border-radius: 8px;
+}
+
+.material-icon {
+    font-size: 2rem;
+    flex-shrink: 0;
+}
+
+.material-info {
+    flex-grow: 1;
+}
+
+.material-info h4 {
+    margin-bottom: 0.25rem;
+    color: #2c3e50;
+}
+
+.file-size {
+    font-size: 0.8rem;
+    color: #666;
+}
+
+.schedule-summary {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.schedule-day h4 {
+    color: #3498db;
+    margin-bottom: 0.5rem;
+}
+
+.schedule-day ul {
+    margin-left: 1rem;
+}
+
+.schedule-day li {
+    margin-bottom: 0.25rem;
+}
+
+.quick-actions {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    gap: 1rem;
+}
+
+.action-btn {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 1rem;
+    background: #f8f9fa;
+    border: none;
+    border-radius: 8px;
+    cursor: pointer;
+    text-decoration: none;
+    color: inherit;
+    transition: background-color 0.3s ease;
+}
+
+.action-btn:hover {
+    background-color: #e9ecef;
+    color: inherit;
+}
+
+.action-icon {
+    font-size: 1.5rem;
+}
+
+/* Material Details Styles */
+.material-details {
+    margin: 2rem 0;
+}
+
+.material-card {
+    background: white;
+    border-radius: 8px;
+    box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+    overflow: hidden;
+}
+
+.material-header {
+    display: flex;
+    align-items: flex-start;
+    gap: 1.5rem;
+    padding: 2rem;
+    background: #f8f9fa;
+}
+
+.material-icon.large {
+    font-size: 3rem;
+    flex-shrink: 0;
+}
+
+.material-info h3 {
+    margin-bottom: 0.5rem;
+    color: #2c3e50;
+}
+
+.file-details {
+    display: flex;
+    gap: 1rem;
+    margin-top: 0.5rem;
+}
+
+.file-type, .update-date {
+    font-size: 0.8rem;
+    padding: 0.25rem 0.5rem;
+    background: #3498db;
+    color: white;
+    border-radius: 4px;
+}
+
+.update-date {
+    background: #95a5a6;
+}
+
+.material-content {
+    padding: 0 2rem;
+}
+
+.material-content h4 {
+    margin-bottom: 0.5rem;
+    color: #2c3e50;
+}
+
+.material-content ul {
+    margin-left: 1rem;
+}
+
+.material-actions {
+    padding: 2rem;
+    display: flex;
+    gap: 1rem;
+}
+
+.additional-materials {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.digital-materials {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.digital-item {
+    background: #f8f9fa;
+    padding: 1.5rem;
+    border-radius: 8px;
+    border-left: 4px solid #3498db;
+}
+
+.digital-item h4 {
+    margin-bottom: 0.5rem;
+    color: #2c3e50;
+}
+
+.download-notice {
+    background: #fff3cd;
+    border: 1px solid #ffeaa7;
+    padding: 2rem;
+    border-radius: 8px;
+    margin-top: 3rem;
+}
+
+.download-notice h3 {
+    margin-bottom: 1rem;
+    color: #856404;
+}
+
+.download-notice ul {
+    margin-left: 1rem;
+}
+
+/* Modal Styles */
+.modal {
+    display: none;
+    position: fixed;
+    z-index: 1000;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0,0,0,0.5);
+}
+
+.modal-content {
+    background-color: white;
+    margin: 15% auto;
+    padding: 2rem;
+    border-radius: 8px;
+    width: 90%;
+    max-width: 500px;
+    position: relative;
+}
+
+.close {
+    position: absolute;
+    right: 1rem;
+    top: 1rem;
+    color: #aaa;
+    font-size: 1.5rem;
+    font-weight: bold;
+    cursor: pointer;
+}
+
+.close:hover {
+    color: #000;
+}
+
+/* Notice Box */
+.notice-box {
+    background: #e8f4fd;
+    border: 1px solid #b3d7ff;
+    padding: 1.5rem;
+    border-radius: 8px;
+    margin: 1rem 0;
+}
+
+.notice-box ul {
+    margin-left: 1rem;
+}
+
+/* Button Variations */
+.btn-secondary {
+    background-color: #95a5a6;
+}
+
+.btn-secondary:hover {
+    background-color: #7f8c8d;
+}
+
 /* Responsive design */
 @media screen and (max-width: 768px) {
     .nav-menu {
@@ -404,5 +1171,65 @@ footer {
 
     h2 {
         font-size: 1.5rem;
+    }
+
+    .registration-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .form-row {
+        grid-template-columns: 1fr;
+    }
+
+    .dashboard-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .login-options {
+        flex-direction: column;
+        align-items: center;
+    }
+
+    .card-actions {
+        flex-direction: column;
+    }
+
+    .ticket-actions {
+        flex-direction: column;
+    }
+
+    .material-actions {
+        flex-direction: column;
+    }
+
+    .material-header {
+        flex-direction: column;
+        text-align: center;
+    }
+
+    .file-details {
+        flex-direction: column;
+        align-items: center;
+    }
+
+    .process-steps {
+        gap: 1rem;
+    }
+
+    .step {
+        flex-direction: column;
+        text-align: center;
+    }
+
+    .info-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .category-grid {
+        grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    }
+
+    .quick-actions {
+        grid-template-columns: repeat(2, 1fr);
     }
 }

--- a/events/details/summer-seminar.html
+++ b/events/details/summer-seminar.html
@@ -25,6 +25,15 @@
                         <a href="../index.html" class="nav-link active">イベント</a>
                     </li>
                     <li class="nav-item">
+                        <a href="../../registration/index.html" class="nav-link">参加登録</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="../../abstracts/index.html" class="nav-link">抄録投稿</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="../../members/index.html" class="nav-link">参加者専用</a>
+                    </li>
+                    <li class="nav-item">
                         <a href="../../contact.html" class="nav-link">お問い合わせ</a>
                     </li>
                 </ul>

--- a/events/index.html
+++ b/events/index.html
@@ -25,6 +25,15 @@
                         <a href="index.html" class="nav-link active">イベント</a>
                     </li>
                     <li class="nav-item">
+                        <a href="../registration/index.html" class="nav-link">参加登録</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="../abstracts/index.html" class="nav-link">抄録投稿</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="../members/index.html" class="nav-link">参加者専用</a>
+                    </li>
+                    <li class="nav-item">
                         <a href="../contact.html" class="nav-link">お問い合わせ</a>
                     </li>
                 </ul>

--- a/index.html
+++ b/index.html
@@ -25,6 +25,15 @@
                         <a href="events/index.html" class="nav-link">イベント</a>
                     </li>
                     <li class="nav-item">
+                        <a href="registration/index.html" class="nav-link">参加登録</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="abstracts/index.html" class="nav-link">抄録投稿</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="members/index.html" class="nav-link">参加者専用</a>
+                    </li>
+                    <li class="nav-item">
                         <a href="contact.html" class="nav-link">お問い合わせ</a>
                     </li>
                 </ul>

--- a/js/script.js
+++ b/js/script.js
@@ -33,6 +33,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
     // Set active navigation item based on current page
     const currentPage = window.location.pathname.split('/').pop() || 'index.html';
+    const currentPath = window.location.pathname;
     const navLinks = document.querySelectorAll('.nav-link');
     
     navLinks.forEach(link => {
@@ -40,8 +41,11 @@ document.addEventListener('DOMContentLoaded', function() {
         const href = link.getAttribute('href');
         if (href === currentPage || 
             (currentPage === '' && href === 'index.html') ||
-            (currentPage.includes('news') && href.includes('news')) ||
-            (currentPage.includes('events') && href.includes('events'))) {
+            (currentPath.includes('/news/') && href.includes('news')) ||
+            (currentPath.includes('/events/') && href.includes('events')) ||
+            (currentPath.includes('/registration/') && href.includes('registration')) ||
+            (currentPath.includes('/abstracts/') && href.includes('abstracts')) ||
+            (currentPath.includes('/members/') && href.includes('members'))) {
             link.classList.add('active');
         }
     });

--- a/members/dashboard.html
+++ b/members/dashboard.html
@@ -1,0 +1,272 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>参加者ダッシュボード - テスト学会</title>
+    <link rel="stylesheet" href="../css/style.css">
+</head>
+<body>
+    <header>
+        <nav class="navbar">
+            <div class="nav-container">
+                <h1 class="nav-logo">テスト学会</h1>
+                <ul class="nav-menu">
+                    <li class="nav-item">
+                        <a href="../index.html" class="nav-link">ホーム</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="../about.html" class="nav-link">学会について</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="../news/index.html" class="nav-link">お知らせ</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="../events/index.html" class="nav-link">イベント</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="../registration/index.html" class="nav-link">参加登録</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="../abstracts/index.html" class="nav-link">抄録投稿</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="index.html" class="nav-link active">参加者専用</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="../contact.html" class="nav-link">お問い合わせ</a>
+                    </li>
+                </ul>
+                <div class="hamburger">
+                    <span class="bar"></span>
+                    <span class="bar"></span>
+                    <span class="bar"></span>
+                </div>
+            </div>
+        </nav>
+    </header>
+
+    <div class="page-header">
+        <div class="container">
+            <h1>参加者ダッシュボード</h1>
+            <p>ようこそ、<span id="participantName">参加者</span>様</p>
+            <div class="header-actions">
+                <button id="logoutBtn" class="btn btn-secondary">ログアウト</button>
+            </div>
+        </div>
+    </div>
+
+    <main class="content">
+        <div class="container">
+            <div class="dashboard-grid">
+                <div class="dashboard-section">
+                    <h2>参加登録情報</h2>
+                    <div class="info-card">
+                        <div class="info-item">
+                            <strong>参加者番号:</strong> <span id="participantNumber">REG12345678</span>
+                        </div>
+                        <div class="info-item">
+                            <strong>登録イベント:</strong> 2025年度学術会議
+                        </div>
+                        <div class="info-item">
+                            <strong>参加日程:</strong> 9月15日（月）〜17日（水）
+                        </div>
+                        <div class="info-item">
+                            <strong>会員区分:</strong> 一般会員
+                        </div>
+                        <div class="info-item">
+                            <strong>決済状況:</strong> <span class="status-paid">決済完了</span>
+                        </div>
+                    </div>
+                    <div class="card-actions">
+                        <button class="btn btn-secondary">登録内容の変更</button>
+                        <button class="btn btn-secondary">領収書ダウンロード</button>
+                    </div>
+                </div>
+
+                <div class="dashboard-section">
+                    <h2>重要なお知らせ</h2>
+                    <div class="notifications">
+                        <div class="notification-item new">
+                            <div class="notification-icon">📢</div>
+                            <div class="notification-content">
+                                <h4>会場へのアクセス情報を更新しました</h4>
+                                <p>新型コロナウイルス感染対策により、入場方法が変更になりました。</p>
+                                <span class="notification-date">2025年5月20日</span>
+                            </div>
+                        </div>
+                        <div class="notification-item">
+                            <div class="notification-icon">📅</div>
+                            <div class="notification-content">
+                                <h4>タイムテーブルが確定しました</h4>
+                                <p>各セッションの詳細スケジュールを公開しました。</p>
+                                <span class="notification-date">2025年5月18日</span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="dashboard-section">
+                    <h2>QRコード参加証</h2>
+                    <div class="qr-ticket">
+                        <div class="qr-code">
+                            <div class="qr-placeholder">
+                                <div class="qr-pattern"></div>
+                                QR CODE
+                            </div>
+                        </div>
+                        <div class="ticket-info">
+                            <p><strong>参加者番号:</strong> REG12345678</p>
+                            <p><strong>氏名:</strong> テスト 太郎</p>
+                            <p><strong>所属:</strong> テスト大学</p>
+                        </div>
+                        <div class="ticket-actions">
+                            <button class="btn btn-primary">チケットをダウンロード</button>
+                            <button class="btn btn-secondary">印刷用ページ</button>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="dashboard-section">
+                    <h2>配布資料</h2>
+                    <div class="materials-list">
+                        <div class="material-item">
+                            <div class="material-icon">📄</div>
+                            <div class="material-info">
+                                <h4>参加者ガイドブック</h4>
+                                <p>イベント概要・注意事項・プログラム</p>
+                                <span class="file-size">PDF, 2.1MB</span>
+                            </div>
+                            <a href="materials.html?file=guidebook" class="btn btn-secondary">ダウンロード</a>
+                        </div>
+                        <div class="material-item">
+                            <div class="material-icon">📊</div>
+                            <div class="material-info">
+                                <h4>講演資料集</h4>
+                                <p>基調講演・招待講演の資料</p>
+                                <span class="file-size">PDF, 15.3MB</span>
+                            </div>
+                            <a href="materials.html?file=lectures" class="btn btn-secondary">ダウンロード</a>
+                        </div>
+                        <div class="material-item">
+                            <div class="material-icon">📚</div>
+                            <div class="material-info">
+                                <h4>論文集</h4>
+                                <p>採択された発表論文の抄録集</p>
+                                <span class="file-size">PDF, 8.7MB</span>
+                            </div>
+                            <a href="materials.html?file=proceedings" class="btn btn-secondary">ダウンロード</a>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="dashboard-section">
+                    <h2>詳細スケジュール</h2>
+                    <div class="schedule-summary">
+                        <div class="schedule-day">
+                            <h4>9月15日（月）</h4>
+                            <ul>
+                                <li>9:00-9:30 受付・開場</li>
+                                <li>9:30-10:30 開会式・基調講演</li>
+                                <li>10:45-12:00 口頭発表セッション1</li>
+                                <li>13:00-14:30 口頭発表セッション2</li>
+                                <li>14:45-16:15 ポスター発表</li>
+                            </ul>
+                        </div>
+                        <div class="schedule-day">
+                            <h4>9月16日（火）</h4>
+                            <ul>
+                                <li>9:00-10:30 招待講演・パネル討論</li>
+                                <li>10:45-12:00 口頭発表セッション3</li>
+                                <li>13:00-14:30 口頭発表セッション4</li>
+                                <li>14:45-16:15 ワークショップ</li>
+                                <li>18:00-20:00 懇親会</li>
+                            </ul>
+                        </div>
+                    </div>
+                    <div class="card-actions">
+                        <button class="btn btn-primary">詳細スケジュールを見る</button>
+                    </div>
+                </div>
+
+                <div class="dashboard-section">
+                    <h2>クイックアクション</h2>
+                    <div class="quick-actions">
+                        <a href="materials.html" class="action-btn">
+                            <div class="action-icon">📂</div>
+                            <span>配布資料</span>
+                        </a>
+                        <a href="../contact.html" class="action-btn">
+                            <div class="action-icon">📧</div>
+                            <span>お問い合わせ</span>
+                        </a>
+                        <a href="../registration/index.html" class="action-btn">
+                            <div class="action-icon">📝</div>
+                            <span>追加登録</span>
+                        </a>
+                        <button class="action-btn" onclick="window.print()">
+                            <div class="action-icon">🖨️</div>
+                            <span>印刷</span>
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </main>
+
+    <footer>
+        <div class="container">
+            <p>&copy; 2025 テスト学会. All rights reserved.</p>
+        </div>
+    </footer>
+
+    <script src="../js/script.js"></script>
+    <script>
+        // ログイン状態確認
+        document.addEventListener('DOMContentLoaded', function() {
+            const isLoggedIn = sessionStorage.getItem('memberLoggedIn') || localStorage.getItem('memberLoggedIn');
+            const participantNumber = sessionStorage.getItem('participantNumber') || localStorage.getItem('participantNumber');
+            
+            if (!isLoggedIn) {
+                window.location.href = 'login.html';
+                return;
+            }
+            
+            // 参加者情報を表示
+            if (participantNumber) {
+                document.getElementById('participantNumber').textContent = participantNumber;
+            }
+            
+            // 参加者名を設定（実際の実装では登録情報から取得）
+            document.getElementById('participantName').textContent = 'テスト 太郎';
+        });
+
+        // ログアウト処理
+        document.getElementById('logoutBtn').addEventListener('click', function() {
+            if (confirm('ログアウトしますか？')) {
+                sessionStorage.removeItem('memberLoggedIn');
+                sessionStorage.removeItem('participantNumber');
+                sessionStorage.removeItem('participantEmail');
+                localStorage.removeItem('memberLoggedIn');
+                localStorage.removeItem('participantNumber');
+                
+                window.location.href = 'login.html';
+            }
+        });
+
+        // 通知クリック処理
+        document.querySelectorAll('.notification-item').forEach(item => {
+            item.addEventListener('click', function() {
+                // 新着マークを削除
+                this.classList.remove('new');
+            });
+        });
+
+        // QRコードダウンロード
+        document.querySelector('.qr-ticket .btn-primary').addEventListener('click', function() {
+            // 実際の実装では、PDFまたは画像ファイルを生成してダウンロード
+            alert('QRコードチケットをダウンロードします。');
+        });
+    </script>
+</body>
+</html>

--- a/members/index.html
+++ b/members/index.html
@@ -1,0 +1,133 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>参加者専用ページ - テスト学会</title>
+    <link rel="stylesheet" href="../css/style.css">
+</head>
+<body>
+    <header>
+        <nav class="navbar">
+            <div class="nav-container">
+                <h1 class="nav-logo">テスト学会</h1>
+                <ul class="nav-menu">
+                    <li class="nav-item">
+                        <a href="../index.html" class="nav-link">ホーム</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="../about.html" class="nav-link">学会について</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="../news/index.html" class="nav-link">お知らせ</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="../events/index.html" class="nav-link">イベント</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="../registration/index.html" class="nav-link">参加登録</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="../abstracts/index.html" class="nav-link">抄録投稿</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="index.html" class="nav-link active">参加者専用</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="../contact.html" class="nav-link">お問い合わせ</a>
+                    </li>
+                </ul>
+                <div class="hamburger">
+                    <span class="bar"></span>
+                    <span class="bar"></span>
+                    <span class="bar"></span>
+                </div>
+            </div>
+        </nav>
+    </header>
+
+    <div class="page-header">
+        <div class="container">
+            <h1>参加者専用ページ</h1>
+            <p>参加登録済みの方限定のコンテンツです</p>
+        </div>
+    </div>
+
+    <main class="content">
+        <div class="container">
+            <div class="login-required-section" id="loginSection">
+                <div class="login-prompt">
+                    <div class="lock-icon">🔒</div>
+                    <h2>ログインが必要です</h2>
+                    <p>この先のコンテンツは参加登録を完了された方のみアクセス可能です。</p>
+                    <p>参加者番号でログインしてください。</p>
+                    
+                    <div class="login-options">
+                        <a href="login.html" class="btn btn-primary">ログイン</a>
+                        <a href="../registration/index.html" class="btn btn-secondary">参加登録</a>
+                    </div>
+                </div>
+
+                <div class="access-info">
+                    <h3>参加者専用コンテンツについて</h3>
+                    <div class="info-grid">
+                        <div class="info-item">
+                            <h4>📋 個人ダッシュボード</h4>
+                            <p>参加登録情報の確認・変更</p>
+                        </div>
+                        <div class="info-item">
+                            <h4>📂 配布資料</h4>
+                            <p>講演資料・論文集のダウンロード</p>
+                        </div>
+                        <div class="info-item">
+                            <h4>📅 詳細スケジュール</h4>
+                            <p>参加イベントの詳細タイムテーブル</p>
+                        </div>
+                        <div class="info-item">
+                            <h4>💬 参加者専用掲示板</h4>
+                            <p>参加者同士の情報交換</p>
+                        </div>
+                        <div class="info-item">
+                            <h4>🎫 電子チケット</h4>
+                            <p>QRコード付き参加証明書</p>
+                        </div>
+                        <div class="info-item">
+                            <h4>📧 専用通知</h4>
+                            <p>重要なお知らせと更新情報</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="members-dashboard" id="membersDashboard" style="display: none;">
+                <!-- ログイン後に表示されるコンテンツ -->
+            </div>
+        </div>
+    </main>
+
+    <footer>
+        <div class="container">
+            <p>&copy; 2025 テスト学会. All rights reserved.</p>
+        </div>
+    </footer>
+
+    <script src="../js/script.js"></script>
+    <script>
+        // ログイン状態確認
+        document.addEventListener('DOMContentLoaded', function() {
+            const isLoggedIn = sessionStorage.getItem('memberLoggedIn');
+            if (isLoggedIn) {
+                showMembersDashboard();
+            }
+        });
+
+        function showMembersDashboard() {
+            document.getElementById('loginSection').style.display = 'none';
+            document.getElementById('membersDashboard').style.display = 'block';
+            
+            // ダッシュボードの内容を読み込み
+            window.location.href = 'dashboard.html';
+        }
+    </script>
+</body>
+</html>

--- a/members/login.html
+++ b/members/login.html
@@ -1,0 +1,192 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>参加者ログイン - テスト学会</title>
+    <link rel="stylesheet" href="../css/style.css">
+</head>
+<body>
+    <header>
+        <nav class="navbar">
+            <div class="nav-container">
+                <h1 class="nav-logo">テスト学会</h1>
+                <ul class="nav-menu">
+                    <li class="nav-item">
+                        <a href="../index.html" class="nav-link">ホーム</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="../about.html" class="nav-link">学会について</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="../news/index.html" class="nav-link">お知らせ</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="../events/index.html" class="nav-link">イベント</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="../registration/index.html" class="nav-link">参加登録</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="../abstracts/index.html" class="nav-link">抄録投稿</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="index.html" class="nav-link active">参加者専用</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="../contact.html" class="nav-link">お問い合わせ</a>
+                    </li>
+                </ul>
+                <div class="hamburger">
+                    <span class="bar"></span>
+                    <span class="bar"></span>
+                    <span class="bar"></span>
+                </div>
+            </div>
+        </nav>
+    </header>
+
+    <div class="page-header">
+        <div class="container">
+            <h1>参加者ログイン</h1>
+            <p>参加者番号とメールアドレスでログイン</p>
+        </div>
+    </div>
+
+    <main class="content">
+        <div class="container">
+            <div class="back-link">
+                <a href="index.html">← 参加者専用ページに戻る</a>
+            </div>
+
+            <div class="login-container">
+                <form class="login-form" id="loginForm">
+                    <h2>ログイン</h2>
+                    
+                    <div class="form-group">
+                        <label for="participantNumber">参加者番号 *</label>
+                        <input type="text" id="participantNumber" name="participantNumber" required placeholder="例：REG12345678">
+                        <small>参加登録完了時に発行された番号を入力してください</small>
+                    </div>
+
+                    <div class="form-group">
+                        <label for="email">メールアドレス *</label>
+                        <input type="email" id="email" name="email" required placeholder="登録時のメールアドレス">
+                    </div>
+
+                    <div class="form-group">
+                        <label class="checkbox-label">
+                            <input type="checkbox" name="rememberLogin">
+                            <span class="checkbox-text">ログイン状態を保持する</span>
+                        </label>
+                    </div>
+
+                    <div class="form-actions">
+                        <button type="submit" class="btn btn-primary">ログイン</button>
+                    </div>
+
+                    <div class="login-help">
+                        <p><a href="#" id="forgotCredentials">参加者番号を忘れた方はこちら</a></p>
+                        <p><a href="../registration/index.html">まだ参加登録がお済みでない方はこちら</a></p>
+                    </div>
+                </form>
+
+                <div class="demo-credentials">
+                    <h3>デモ用ログイン情報</h3>
+                    <div class="demo-info">
+                        <p><strong>参加者番号:</strong> REG12345678</p>
+                        <p><strong>メールアドレス:</strong> demo@test-society.jp</p>
+                        <p><small>※ テスト環境用のダミーアカウントです</small></p>
+                    </div>
+                </div>
+            </div>
+
+            <div id="forgotModal" class="modal" style="display: none;">
+                <div class="modal-content">
+                    <span class="close" id="closeModal">&times;</span>
+                    <h3>参加者番号の確認</h3>
+                    <p>参加者番号を忘れた場合は、登録時のメールアドレスを入力してください。確認メールをお送りします。</p>
+                    
+                    <form id="forgotForm">
+                        <div class="form-group">
+                            <label for="forgotEmail">メールアドレス</label>
+                            <input type="email" id="forgotEmail" name="forgotEmail" required>
+                        </div>
+                        <div class="form-actions">
+                            <button type="submit" class="btn btn-primary">確認メールを送信</button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </main>
+
+    <footer>
+        <div class="container">
+            <p>&copy; 2025 テスト学会. All rights reserved.</p>
+        </div>
+    </footer>
+
+    <script src="../js/script.js"></script>
+    <script>
+        // ログインフォーム処理
+        document.getElementById('loginForm').addEventListener('submit', function(e) {
+            e.preventDefault();
+            
+            const participantNumber = document.getElementById('participantNumber').value;
+            const email = document.getElementById('email').value;
+            const rememberLogin = document.querySelector('input[name="rememberLogin"]').checked;
+            
+            // 簡単な認証シミュレーション
+            if (participantNumber === 'REG12345678' && email === 'demo@test-society.jp') {
+                // ログイン成功
+                sessionStorage.setItem('memberLoggedIn', 'true');
+                sessionStorage.setItem('participantNumber', participantNumber);
+                sessionStorage.setItem('participantEmail', email);
+                
+                if (rememberLogin) {
+                    localStorage.setItem('memberLoggedIn', 'true');
+                    localStorage.setItem('participantNumber', participantNumber);
+                }
+                
+                // ダッシュボードへリダイレクト
+                window.location.href = 'dashboard.html';
+            } else {
+                alert('参加者番号またはメールアドレスが正しくありません。');
+            }
+        });
+
+        // 参加者番号忘れモーダル
+        document.getElementById('forgotCredentials').addEventListener('click', function(e) {
+            e.preventDefault();
+            document.getElementById('forgotModal').style.display = 'block';
+        });
+
+        document.getElementById('closeModal').addEventListener('click', function() {
+            document.getElementById('forgotModal').style.display = 'none';
+        });
+
+        document.getElementById('forgotForm').addEventListener('submit', function(e) {
+            e.preventDefault();
+            alert('確認メールを送信しました。メールボックスをご確認ください。');
+            document.getElementById('forgotModal').style.display = 'none';
+        });
+
+        // モーダル外クリックで閉じる
+        window.addEventListener('click', function(e) {
+            const modal = document.getElementById('forgotModal');
+            if (e.target === modal) {
+                modal.style.display = 'none';
+            }
+        });
+
+        // ページ読み込み時にログイン状態確認
+        document.addEventListener('DOMContentLoaded', function() {
+            const isLoggedIn = sessionStorage.getItem('memberLoggedIn') || localStorage.getItem('memberLoggedIn');
+            if (isLoggedIn) {
+                window.location.href = 'dashboard.html';
+            }
+        });
+    </script>
+</body>
+</html>

--- a/members/materials.html
+++ b/members/materials.html
@@ -1,0 +1,314 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>配布資料 - テスト学会</title>
+    <link rel="stylesheet" href="../css/style.css">
+</head>
+<body>
+    <header>
+        <nav class="navbar">
+            <div class="nav-container">
+                <h1 class="nav-logo">テスト学会</h1>
+                <ul class="nav-menu">
+                    <li class="nav-item">
+                        <a href="../index.html" class="nav-link">ホーム</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="../about.html" class="nav-link">学会について</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="../news/index.html" class="nav-link">お知らせ</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="../events/index.html" class="nav-link">イベント</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="../registration/index.html" class="nav-link">参加登録</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="../abstracts/index.html" class="nav-link">抄録投稿</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="index.html" class="nav-link active">参加者専用</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="../contact.html" class="nav-link">お問い合わせ</a>
+                    </li>
+                </ul>
+                <div class="hamburger">
+                    <span class="bar"></span>
+                    <span class="bar"></span>
+                    <span class="bar"></span>
+                </div>
+            </div>
+        </nav>
+    </header>
+
+    <div class="page-header">
+        <div class="container">
+            <h1>配布資料</h1>
+            <p>参加者専用の資料ダウンロードページ</p>
+        </div>
+    </div>
+
+    <main class="content">
+        <div class="container">
+            <div class="back-link">
+                <a href="dashboard.html">← ダッシュボードに戻る</a>
+            </div>
+
+            <section class="content-section">
+                <h2>📋 参加者ガイドブック</h2>
+                <div class="material-details">
+                    <div class="material-card">
+                        <div class="material-header">
+                            <div class="material-icon large">📄</div>
+                            <div class="material-info">
+                                <h3>2025年度学術会議 参加者ガイドブック</h3>
+                                <p>イベントの詳細情報、注意事項、会場案内、プログラム概要</p>
+                                <div class="file-details">
+                                    <span class="file-type">PDF</span>
+                                    <span class="file-size">2.1MB</span>
+                                    <span class="update-date">更新日: 2025年5月20日</span>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="material-content">
+                            <h4>含まれる内容</h4>
+                            <ul>
+                                <li>会場アクセス・駐車場情報</li>
+                                <li>受付・チェックイン手順</li>
+                                <li>感染対策ガイドライン</li>
+                                <li>各セッション概要</li>
+                                <li>懇親会・ネットワーキング情報</li>
+                                <li>Wi-Fi・設備利用案内</li>
+                            </ul>
+                        </div>
+                        <div class="material-actions">
+                            <button class="btn btn-primary" onclick="downloadFile('guidebook')">ダウンロード</button>
+                            <button class="btn btn-secondary" onclick="previewFile('guidebook')">プレビュー</button>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <section class="content-section">
+                <h2>📊 講演資料集</h2>
+                <div class="material-details">
+                    <div class="material-card">
+                        <div class="material-header">
+                            <div class="material-icon large">📊</div>
+                            <div class="material-info">
+                                <h3>基調講演・招待講演資料集</h3>
+                                <p>著名研究者による基調講演と招待講演のスライド資料</p>
+                                <div class="file-details">
+                                    <span class="file-type">PDF</span>
+                                    <span class="file-size">15.3MB</span>
+                                    <span class="update-date">更新日: 2025年5月22日</span>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="material-content">
+                            <h4>収録講演</h4>
+                            <ul>
+                                <li>基調講演：「AI時代の研究倫理」- 田中教授（東京大学）</li>
+                                <li>招待講演1：「量子コンピュータの現在と未来」- 佐藤博士（理研）</li>
+                                <li>招待講演2：「持続可能な社会に向けた技術革新」- 鈴木氏（○○研究所）</li>
+                                <li>パネル討論：「次世代研究者への提言」</li>
+                            </ul>
+                        </div>
+                        <div class="material-actions">
+                            <button class="btn btn-primary" onclick="downloadFile('lectures')">ダウンロード</button>
+                            <button class="btn btn-secondary" onclick="previewFile('lectures')">プレビュー</button>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <section class="content-section">
+                <h2>📚 論文集</h2>
+                <div class="material-details">
+                    <div class="material-card">
+                        <div class="material-header">
+                            <div class="material-icon large">📚</div>
+                            <div class="material-info">
+                                <h3>2025年度学術会議 論文集</h3>
+                                <p>採択された発表論文の抄録とプログラム詳細</p>
+                                <div class="file-details">
+                                    <span class="file-type">PDF</span>
+                                    <span class="file-size">8.7MB</span>
+                                    <span class="update-date">更新日: 2025年5月25日</span>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="material-content">
+                            <h4>収録内容</h4>
+                            <ul>
+                                <li>口頭発表論文抄録（50件）</li>
+                                <li>ポスター発表論文抄録（100件）</li>
+                                <li>詳細プログラム・タイムテーブル</li>
+                                <li>発表者索引</li>
+                                <li>キーワード索引</li>
+                                <li>研究分野別分類</li>
+                            </ul>
+                        </div>
+                        <div class="material-actions">
+                            <button class="btn btn-primary" onclick="downloadFile('proceedings')">ダウンロード</button>
+                            <button class="btn btn-secondary" onclick="previewFile('proceedings')">プレビュー</button>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <section class="content-section">
+                <h2>📑 追加資料</h2>
+                <div class="additional-materials">
+                    <div class="material-item">
+                        <div class="material-icon">🗺️</div>
+                        <div class="material-info">
+                            <h4>会場フロアマップ</h4>
+                            <p>会場内の詳細地図・各セッション会場の位置</p>
+                            <span class="file-size">PDF, 0.8MB</span>
+                        </div>
+                        <button class="btn btn-secondary" onclick="downloadFile('floormap')">ダウンロード</button>
+                    </div>
+
+                    <div class="material-item">
+                        <div class="material-icon">📋</div>
+                        <div class="material-info">
+                            <h4>評価フォーム</h4>
+                            <p>講演・セッション評価用フォーム</p>
+                            <span class="file-size">PDF, 0.3MB</span>
+                        </div>
+                        <button class="btn btn-secondary" onclick="downloadFile('evaluation')">ダウンロード</button>
+                    </div>
+
+                    <div class="material-item">
+                        <div class="material-icon">📇</div>
+                        <div class="material-info">
+                            <h4>参加者名簿</h4>
+                            <p>参加者リスト（希望者のみ掲載）</p>
+                            <span class="file-size">PDF, 1.2MB</span>
+                        </div>
+                        <button class="btn btn-secondary" onclick="downloadFile('participants')">ダウンロード</button>
+                    </div>
+
+                    <div class="material-item">
+                        <div class="material-icon">📞</div>
+                        <div class="material-info">
+                            <h4>緊急連絡先一覧</h4>
+                            <p>会場・運営事務局・緊急時連絡先</p>
+                            <span class="file-size">PDF, 0.2MB</span>
+                        </div>
+                        <button class="btn btn-secondary" onclick="downloadFile('contacts')">ダウンロード</button>
+                    </div>
+                </div>
+            </section>
+
+            <section class="content-section">
+                <h2>📱 デジタル資料</h2>
+                <div class="digital-materials">
+                    <div class="digital-item">
+                        <h4>🎥 録画講演（イベント後公開予定）</h4>
+                        <p>基調講演・招待講演の録画動画は、イベント終了後にこちらで公開予定です。</p>
+                    </div>
+                    <div class="digital-item">
+                        <h4>💬 参加者掲示板</h4>
+                        <p>参加者同士の情報交換や質疑応答のためのオンライン掲示板をご利用いただけます。</p>
+                        <a href="#" class="btn btn-secondary">掲示板へ</a>
+                    </div>
+                </div>
+            </section>
+
+            <div class="download-notice">
+                <h3>⚠️ ダウンロードに関する注意事項</h3>
+                <ul>
+                    <li>資料は参加者の方のみダウンロード可能です</li>
+                    <li>資料の無断転載・配布は禁止されています</li>
+                    <li>資料は個人の学習・研究目的でのみご利用ください</li>
+                    <li>一部の資料は著作権の都合により、イベント後に削除される場合があります</li>
+                    <li>ダウンロードが困難な場合は、運営事務局までお問い合わせください</li>
+                </ul>
+            </div>
+        </div>
+    </main>
+
+    <footer>
+        <div class="container">
+            <p>&copy; 2025 テスト学会. All rights reserved.</p>
+        </div>
+    </footer>
+
+    <script src="../js/script.js"></script>
+    <script>
+        // ログイン状態確認
+        document.addEventListener('DOMContentLoaded', function() {
+            const isLoggedIn = sessionStorage.getItem('memberLoggedIn') || localStorage.getItem('memberLoggedIn');
+            if (!isLoggedIn) {
+                alert('ログインが必要です。');
+                window.location.href = 'login.html';
+                return;
+            }
+        });
+
+        // ファイルダウンロード関数
+        function downloadFile(fileType) {
+            const fileNames = {
+                'guidebook': '参加者ガイドブック.pdf',
+                'lectures': '講演資料集.pdf',
+                'proceedings': '論文集.pdf',
+                'floormap': '会場フロアマップ.pdf',
+                'evaluation': '評価フォーム.pdf',
+                'participants': '参加者名簿.pdf',
+                'contacts': '緊急連絡先一覧.pdf'
+            };
+            
+            const fileName = fileNames[fileType] || 'ファイル.pdf';
+            
+            // 実際の実装では、サーバーからファイルをダウンロード
+            // ここではダウンロードのシミュレーション
+            console.log(`ダウンロード開始: ${fileName}`);
+            
+            // ダウンロード数をカウント（実際の実装ではサーバーサイドで記録）
+            let downloadCount = parseInt(localStorage.getItem(`download_${fileType}`) || '0');
+            downloadCount++;
+            localStorage.setItem(`download_${fileType}`, downloadCount.toString());
+            
+            alert(`${fileName} のダウンロードを開始します。`);
+        }
+
+        // ファイルプレビュー関数
+        function previewFile(fileType) {
+            const fileNames = {
+                'guidebook': '参加者ガイドブック',
+                'lectures': '講演資料集',
+                'proceedings': '論文集'
+            };
+            
+            const fileName = fileNames[fileType] || 'ファイル';
+            
+            // 実際の実装では、PDFビューアーまたは新しいタブでプレビューを表示
+            alert(`${fileName} のプレビューを表示します。`);
+        }
+
+        // URLパラメータから特定のファイルを開く
+        const urlParams = new URLSearchParams(window.location.search);
+        const fileParam = urlParams.get('file');
+        if (fileParam) {
+            // 特定のセクションにスクロール
+            setTimeout(() => {
+                const section = document.querySelector(`button[onclick="downloadFile('${fileParam}')"]`);
+                if (section) {
+                    section.scrollIntoView({ behavior: 'smooth', block: 'center' });
+                    section.style.backgroundColor = '#e3f2fd';
+                    setTimeout(() => {
+                        section.style.backgroundColor = '';
+                    }, 2000);
+                }
+            }, 500);
+        }
+    </script>
+</body>
+</html>

--- a/news/articles/conference-2025.html
+++ b/news/articles/conference-2025.html
@@ -25,6 +25,15 @@
                         <a href="../../events/index.html" class="nav-link">イベント</a>
                     </li>
                     <li class="nav-item">
+                        <a href="../../registration/index.html" class="nav-link">参加登録</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="../../abstracts/index.html" class="nav-link">抄録投稿</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="../../members/index.html" class="nav-link">参加者専用</a>
+                    </li>
+                    <li class="nav-item">
                         <a href="../../contact.html" class="nav-link">お問い合わせ</a>
                     </li>
                 </ul>

--- a/news/articles/journal-vol12.html
+++ b/news/articles/journal-vol12.html
@@ -25,6 +25,15 @@
                         <a href="../../events/index.html" class="nav-link">イベント</a>
                     </li>
                     <li class="nav-item">
+                        <a href="../../registration/index.html" class="nav-link">参加登録</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="../../abstracts/index.html" class="nav-link">抄録投稿</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="../../members/index.html" class="nav-link">参加者専用</a>
+                    </li>
+                    <li class="nav-item">
                         <a href="../../contact.html" class="nav-link">お問い合わせ</a>
                     </li>
                 </ul>

--- a/news/articles/membership-renewal.html
+++ b/news/articles/membership-renewal.html
@@ -25,6 +25,15 @@
                         <a href="../../events/index.html" class="nav-link">イベント</a>
                     </li>
                     <li class="nav-item">
+                        <a href="../../registration/index.html" class="nav-link">参加登録</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="../../abstracts/index.html" class="nav-link">抄録投稿</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="../../members/index.html" class="nav-link">参加者専用</a>
+                    </li>
+                    <li class="nav-item">
                         <a href="../../contact.html" class="nav-link">お問い合わせ</a>
                     </li>
                 </ul>

--- a/news/index.html
+++ b/news/index.html
@@ -25,6 +25,15 @@
                         <a href="../events/index.html" class="nav-link">イベント</a>
                     </li>
                     <li class="nav-item">
+                        <a href="../registration/index.html" class="nav-link">参加登録</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="../abstracts/index.html" class="nav-link">抄録投稿</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="../members/index.html" class="nav-link">参加者専用</a>
+                    </li>
+                    <li class="nav-item">
                         <a href="../contact.html" class="nav-link">お問い合わせ</a>
                     </li>
                 </ul>

--- a/registration/conference.html
+++ b/registration/conference.html
@@ -1,0 +1,282 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>学術会議参加登録 - テスト学会</title>
+    <link rel="stylesheet" href="../css/style.css">
+</head>
+<body>
+    <header>
+        <nav class="navbar">
+            <div class="nav-container">
+                <h1 class="nav-logo">テスト学会</h1>
+                <ul class="nav-menu">
+                    <li class="nav-item">
+                        <a href="../index.html" class="nav-link">ホーム</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="../about.html" class="nav-link">学会について</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="../news/index.html" class="nav-link">お知らせ</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="../events/index.html" class="nav-link">イベント</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="index.html" class="nav-link active">参加登録</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="../abstracts/index.html" class="nav-link">抄録投稿</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="../members/index.html" class="nav-link">参加者専用</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="../contact.html" class="nav-link">お問い合わせ</a>
+                    </li>
+                </ul>
+                <div class="hamburger">
+                    <span class="bar"></span>
+                    <span class="bar"></span>
+                    <span class="bar"></span>
+                </div>
+            </div>
+        </nav>
+    </header>
+
+    <div class="page-header">
+        <div class="container">
+            <h1>2025年度学術会議 参加登録</h1>
+            <p>2025年9月15日（月）〜17日（水） 東京国際会議場</p>
+        </div>
+    </div>
+
+    <main class="content">
+        <div class="container">
+            <div class="back-link">
+                <a href="index.html">← 参加登録一覧に戻る</a>
+            </div>
+
+            <form class="registration-form" id="conferenceForm">
+                <div class="form-section">
+                    <h2>参加者情報</h2>
+                    
+                    <div class="form-row">
+                        <div class="form-group">
+                            <label for="lastName">姓 *</label>
+                            <input type="text" id="lastName" name="lastName" required>
+                        </div>
+                        <div class="form-group">
+                            <label for="firstName">名 *</label>
+                            <input type="text" id="firstName" name="firstName" required>
+                        </div>
+                    </div>
+
+                    <div class="form-row">
+                        <div class="form-group">
+                            <label for="lastNameKana">姓（カナ） *</label>
+                            <input type="text" id="lastNameKana" name="lastNameKana" required>
+                        </div>
+                        <div class="form-group">
+                            <label for="firstNameKana">名（カナ） *</label>
+                            <input type="text" id="firstNameKana" name="firstNameKana" required>
+                        </div>
+                    </div>
+
+                    <div class="form-group">
+                        <label for="email">メールアドレス *</label>
+                        <input type="email" id="email" name="email" required>
+                    </div>
+
+                    <div class="form-group">
+                        <label for="phone">電話番号 *</label>
+                        <input type="tel" id="phone" name="phone" required>
+                    </div>
+
+                    <div class="form-group">
+                        <label for="affiliation">所属機関</label>
+                        <input type="text" id="affiliation" name="affiliation">
+                    </div>
+
+                    <div class="form-group">
+                        <label for="position">役職・学年</label>
+                        <input type="text" id="position" name="position">
+                    </div>
+                </div>
+
+                <div class="form-section">
+                    <h2>参加区分・参加費</h2>
+                    
+                    <div class="form-group">
+                        <label>会員区分 *</label>
+                        <div class="radio-group">
+                            <label class="radio-label">
+                                <input type="radio" name="memberType" value="regular" required>
+                                <span class="radio-text">一般会員（15,000円）</span>
+                            </label>
+                            <label class="radio-label">
+                                <input type="radio" name="memberType" value="student" required>
+                                <span class="radio-text">学生会員（8,000円）</span>
+                            </label>
+                            <label class="radio-label">
+                                <input type="radio" name="memberType" value="non-member" required>
+                                <span class="radio-text">非会員（25,000円）</span>
+                            </label>
+                        </div>
+                    </div>
+
+                    <div class="form-group">
+                        <label>参加日程 *</label>
+                        <div class="checkbox-group">
+                            <label class="checkbox-label">
+                                <input type="checkbox" name="participationDays" value="day1" required>
+                                <span class="checkbox-text">9月15日（月）1日目</span>
+                            </label>
+                            <label class="checkbox-label">
+                                <input type="checkbox" name="participationDays" value="day2">
+                                <span class="checkbox-text">9月16日（火）2日目</span>
+                            </label>
+                            <label class="checkbox-label">
+                                <input type="checkbox" name="participationDays" value="day3">
+                                <span class="checkbox-text">9月17日（水）3日目</span>
+                            </label>
+                        </div>
+                    </div>
+
+                    <div class="form-group">
+                        <label>オプション</label>
+                        <div class="checkbox-group">
+                            <label class="checkbox-label">
+                                <input type="checkbox" name="options" value="banquet">
+                                <span class="checkbox-text">懇親会参加（5,000円）</span>
+                            </label>
+                            <label class="checkbox-label">
+                                <input type="checkbox" name="options" value="proceedings">
+                                <span class="checkbox-text">論文集（2,000円）</span>
+                            </label>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="form-section">
+                    <h2>支払い方法</h2>
+                    
+                    <div class="form-group">
+                        <label>お支払い方法 *</label>
+                        <div class="radio-group">
+                            <label class="radio-label">
+                                <input type="radio" name="paymentMethod" value="credit" required>
+                                <span class="radio-text">クレジットカード（即時決済）</span>
+                            </label>
+                            <label class="radio-label">
+                                <input type="radio" name="paymentMethod" value="bank" required>
+                                <span class="radio-text">銀行振込（請求書発行）</span>
+                            </label>
+                            <label class="radio-label">
+                                <input type="radio" name="paymentMethod" value="onsite" required>
+                                <span class="radio-text">現地決済</span>
+                            </label>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="form-section">
+                    <h2>特記事項</h2>
+                    
+                    <div class="form-group">
+                        <label for="specialRequests">食事制限・アクセシビリティ等のご要望</label>
+                        <textarea id="specialRequests" name="specialRequests" rows="4" placeholder="アレルギー、車椅子でのアクセス、その他のご要望があればお書きください"></textarea>
+                    </div>
+                </div>
+
+                <div class="total-amount">
+                    <h3>合計金額: <span id="totalAmount">0</span>円</h3>
+                </div>
+
+                <div class="form-actions">
+                    <button type="button" class="btn btn-secondary" onclick="window.history.back()">戻る</button>
+                    <button type="submit" class="btn btn-primary">決済画面へ進む</button>
+                </div>
+            </form>
+        </div>
+    </main>
+
+    <footer>
+        <div class="container">
+            <p>&copy; 2025 テスト学会. All rights reserved.</p>
+        </div>
+    </footer>
+
+    <script src="../js/script.js"></script>
+    <script>
+        // 金額計算
+        function calculateTotal() {
+            let total = 0;
+            
+            // 会員区分による参加費
+            const memberType = document.querySelector('input[name="memberType"]:checked');
+            if (memberType) {
+                switch(memberType.value) {
+                    case 'regular': total += 15000; break;
+                    case 'student': total += 8000; break;
+                    case 'non-member': total += 25000; break;
+                }
+            }
+            
+            // オプション
+            const options = document.querySelectorAll('input[name="options"]:checked');
+            options.forEach(option => {
+                switch(option.value) {
+                    case 'banquet': total += 5000; break;
+                    case 'proceedings': total += 2000; break;
+                }
+            });
+            
+            document.getElementById('totalAmount').textContent = total.toLocaleString();
+        }
+        
+        // イベントリスナー
+        document.querySelectorAll('input[name="memberType"], input[name="options"]').forEach(input => {
+            input.addEventListener('change', calculateTotal);
+        });
+        
+        // フォーム送信
+        document.getElementById('conferenceForm').addEventListener('submit', function(e) {
+            e.preventDefault();
+            
+            // フォームデータをセッションストレージに保存
+            const formData = new FormData(this);
+            const data = {};
+            for (let [key, value] of formData.entries()) {
+                if (data[key]) {
+                    if (Array.isArray(data[key])) {
+                        data[key].push(value);
+                    } else {
+                        data[key] = [data[key], value];
+                    }
+                } else {
+                    data[key] = value;
+                }
+            }
+            
+            // 参加日程のチェック
+            const participationDays = document.querySelectorAll('input[name="participationDays"]:checked');
+            if (participationDays.length === 0) {
+                alert('参加日程を1日以上選択してください。');
+                return;
+            }
+            
+            sessionStorage.setItem('conferenceRegistration', JSON.stringify(data));
+            sessionStorage.setItem('totalAmount', document.getElementById('totalAmount').textContent);
+            
+            // 決済画面へ
+            window.location.href = 'payment.html?event=conference';
+        });
+        
+        // 初期計算
+        calculateTotal();
+    </script>
+</body>
+</html>

--- a/registration/index.html
+++ b/registration/index.html
@@ -1,0 +1,133 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>参加登録 - テスト学会</title>
+    <link rel="stylesheet" href="../css/style.css">
+</head>
+<body>
+    <header>
+        <nav class="navbar">
+            <div class="nav-container">
+                <h1 class="nav-logo">テスト学会</h1>
+                <ul class="nav-menu">
+                    <li class="nav-item">
+                        <a href="../index.html" class="nav-link">ホーム</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="../about.html" class="nav-link">学会について</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="../news/index.html" class="nav-link">お知らせ</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="../events/index.html" class="nav-link">イベント</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="index.html" class="nav-link active">参加登録</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="../abstracts/index.html" class="nav-link">抄録投稿</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="../members/index.html" class="nav-link">参加者専用</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="../contact.html" class="nav-link">お問い合わせ</a>
+                    </li>
+                </ul>
+                <div class="hamburger">
+                    <span class="bar"></span>
+                    <span class="bar"></span>
+                    <span class="bar"></span>
+                </div>
+            </div>
+        </nav>
+    </header>
+
+    <div class="page-header">
+        <div class="container">
+            <h1>参加登録</h1>
+            <p>各種イベントへの参加登録を承っております</p>
+        </div>
+    </div>
+
+    <main class="content">
+        <div class="container">
+            <section class="content-section">
+                <h2>参加可能なイベント</h2>
+                
+                <div class="registration-grid">
+                    <div class="registration-card">
+                        <div class="registration-header">
+                            <h3>2025年度学術会議</h3>
+                            <div class="registration-status available">受付中</div>
+                        </div>
+                        <div class="registration-details">
+                            <p><strong>開催日時:</strong> 2025年9月15日（月）〜17日（水）</p>
+                            <p><strong>開催場所:</strong> 東京国際会議場</p>
+                            <p><strong>参加費:</strong></p>
+                            <ul>
+                                <li>一般会員: 15,000円</li>
+                                <li>学生会員: 8,000円</li>
+                                <li>非会員: 25,000円</li>
+                            </ul>
+                            <p><strong>登録締切:</strong> 2025年8月31日（土）</p>
+                        </div>
+                        <div class="registration-actions">
+                            <a href="conference.html" class="btn">詳細・申込み</a>
+                        </div>
+                    </div>
+
+                    <div class="registration-card">
+                        <div class="registration-header">
+                            <h3>夏季セミナー2025</h3>
+                            <div class="registration-status available">受付中</div>
+                        </div>
+                        <div class="registration-details">
+                            <p><strong>開催日時:</strong> 2025年6月15日（土） 13:00-17:00</p>
+                            <p><strong>開催場所:</strong> 東京国際会議場</p>
+                            <p><strong>参加費:</strong></p>
+                            <ul>
+                                <li>会員: 3,000円</li>
+                                <li>非会員: 5,000円</li>
+                            </ul>
+                            <p><strong>登録締切:</strong> 2025年6月10日（火）</p>
+                        </div>
+                        <div class="registration-actions">
+                            <a href="seminar.html" class="btn">詳細・申込み</a>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <section class="content-section">
+                <h2>登録に関する注意事項</h2>
+                <div class="notice-box">
+                    <ul>
+                        <li>参加費は登録完了後、指定の方法でお支払いください</li>
+                        <li>登録内容の変更は締切日の3日前まで可能です</li>
+                        <li>キャンセルの場合、開催日の1週間前までにご連絡ください</li>
+                        <li>キャンセル料について詳しくは各イベントページをご確認ください</li>
+                        <li>お支払い方法: クレジットカード、銀行振込、現地決済</li>
+                    </ul>
+                </div>
+            </section>
+
+            <section class="content-section">
+                <h2>お問い合わせ</h2>
+                <p>参加登録に関するご質問は、<a href="../contact.html">お問い合わせページ</a>からご連絡ください。</p>
+            </section>
+        </div>
+    </main>
+
+    <footer>
+        <div class="container">
+            <p>&copy; 2025 テスト学会. All rights reserved.</p>
+        </div>
+    </footer>
+
+    <script src="../js/script.js"></script>
+</body>
+</html>

--- a/registration/payment.html
+++ b/registration/payment.html
@@ -1,0 +1,299 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>決済画面 - テスト学会</title>
+    <link rel="stylesheet" href="../css/style.css">
+</head>
+<body>
+    <header>
+        <nav class="navbar">
+            <div class="nav-container">
+                <h1 class="nav-logo">テスト学会</h1>
+                <ul class="nav-menu">
+                    <li class="nav-item">
+                        <a href="../index.html" class="nav-link">ホーム</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="../about.html" class="nav-link">学会について</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="../news/index.html" class="nav-link">お知らせ</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="../events/index.html" class="nav-link">イベント</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="index.html" class="nav-link active">参加登録</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="../abstracts/index.html" class="nav-link">抄録投稿</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="../members/index.html" class="nav-link">参加者専用</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="../contact.html" class="nav-link">お問い合わせ</a>
+                    </li>
+                </ul>
+                <div class="hamburger">
+                    <span class="bar"></span>
+                    <span class="bar"></span>
+                    <span class="bar"></span>
+                </div>
+            </div>
+        </nav>
+    </header>
+
+    <div class="page-header">
+        <div class="container">
+            <h1>決済画面</h1>
+            <p>参加登録の確認とお支払い</p>
+        </div>
+    </div>
+
+    <main class="content">
+        <div class="container">
+            <div class="payment-container">
+                <div class="payment-summary">
+                    <h2>申込み内容確認</h2>
+                    <div id="summaryContent">
+                        <!-- JavaScript で動的に生成 -->
+                    </div>
+                </div>
+
+                <div class="payment-form" id="paymentForm">
+                    <h2>お支払い情報</h2>
+                    
+                    <div class="payment-method-section" id="creditCardSection" style="display: none;">
+                        <h3>クレジットカード情報</h3>
+                        <div class="form-group">
+                            <label for="cardNumber">カード番号 *</label>
+                            <input type="text" id="cardNumber" name="cardNumber" placeholder="1234 5678 9012 3456" maxlength="19">
+                        </div>
+                        <div class="form-row">
+                            <div class="form-group">
+                                <label for="expiryDate">有効期限 *</label>
+                                <input type="text" id="expiryDate" name="expiryDate" placeholder="MM/YY" maxlength="5">
+                            </div>
+                            <div class="form-group">
+                                <label for="cvv">セキュリティコード *</label>
+                                <input type="text" id="cvv" name="cvv" placeholder="123" maxlength="4">
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            <label for="cardName">カード名義人 *</label>
+                            <input type="text" id="cardName" name="cardName" placeholder="YAMADA TARO">
+                        </div>
+                    </div>
+
+                    <div class="payment-method-section" id="bankTransferSection" style="display: none;">
+                        <h3>銀行振込先情報</h3>
+                        <div class="bank-info">
+                            <p><strong>銀行名:</strong> テスト銀行</p>
+                            <p><strong>支店名:</strong> 学術支店</p>
+                            <p><strong>口座種別:</strong> 普通</p>
+                            <p><strong>口座番号:</strong> 1234567</p>
+                            <p><strong>口座名義:</strong> テスト学会</p>
+                            <p><strong>振込期限:</strong> 登録完了後1週間以内</p>
+                        </div>
+                        <div class="notice-box">
+                            <p>※ 振込手数料はお客様のご負担となります</p>
+                            <p>※ 振込名義人は登録者のお名前でお願いします</p>
+                        </div>
+                    </div>
+
+                    <div class="payment-method-section" id="onsitePaymentSection" style="display: none;">
+                        <h3>現地決済について</h3>
+                        <div class="notice-box">
+                            <p>当日、受付にて現金またはクレジットカードでのお支払いが可能です。</p>
+                            <p>※ 現地決済の場合、キャンセル時の返金は致しかねます</p>
+                            <p>※ 混雑緩和のため、事前決済をお勧めします</p>
+                        </div>
+                    </div>
+
+                    <div class="total-display">
+                        <h3>お支払い金額: <span id="finalAmount">0</span>円</h3>
+                    </div>
+
+                    <div class="form-actions">
+                        <button type="button" class="btn btn-secondary" onclick="window.history.back()">戻る</button>
+                        <button type="button" class="btn btn-primary" id="processPayment">決済を実行</button>
+                    </div>
+                </div>
+
+                <div class="payment-complete" id="paymentComplete" style="display: none;">
+                    <div class="success-message">
+                        <h2>✅ 決済が完了しました</h2>
+                        <p>参加登録ありがとうございます。確認メールをお送りしました。</p>
+                        <div class="registration-number">
+                            <p><strong>登録番号:</strong> <span id="registrationNumber"></span></p>
+                        </div>
+                        <div class="next-steps">
+                            <h3>今後の流れ</h3>
+                            <ul>
+                                <li>確認メールに記載された参加者番号をお控えください</li>
+                                <li>当日は確認メールまたは参加者番号をお持ちください</li>
+                                <li>詳細な案内は開催1週間前にお送りします</li>
+                            </ul>
+                        </div>
+                        <div class="form-actions">
+                            <a href="../index.html" class="btn btn-primary">ホームに戻る</a>
+                            <a href="../members/login.html" class="btn btn-secondary">参加者専用ページへ</a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </main>
+
+    <footer>
+        <div class="container">
+            <p>&copy; 2025 テスト学会. All rights reserved.</p>
+        </div>
+    </footer>
+
+    <script src="../js/script.js"></script>
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            const urlParams = new URLSearchParams(window.location.search);
+            const eventType = urlParams.get('event');
+            
+            let registrationData = null;
+            let totalAmount = '0';
+            
+            // 登録データの取得
+            if (eventType === 'conference') {
+                registrationData = JSON.parse(sessionStorage.getItem('conferenceRegistration') || '{}');
+                totalAmount = sessionStorage.getItem('totalAmount') || '0';
+            } else if (eventType === 'seminar') {
+                registrationData = JSON.parse(sessionStorage.getItem('seminarRegistration') || '{}');
+                totalAmount = sessionStorage.getItem('totalAmount') || '0';
+            }
+            
+            if (!registrationData || Object.keys(registrationData).length === 0) {
+                alert('登録データが見つかりません。最初からやり直してください。');
+                window.location.href = 'index.html';
+                return;
+            }
+            
+            // 申込み内容の表示
+            displaySummary(registrationData, eventType, totalAmount);
+            
+            // 支払い方法に応じた表示切り替え
+            showPaymentMethod(registrationData.paymentMethod);
+            
+            // 決済ボタンの処理
+            document.getElementById('processPayment').addEventListener('click', function() {
+                processPayment(registrationData, eventType, totalAmount);
+            });
+        });
+        
+        function displaySummary(data, eventType, amount) {
+            const summaryDiv = document.getElementById('summaryContent');
+            const eventName = eventType === 'conference' ? '2025年度学術会議' : '夏季セミナー2025';
+            
+            let html = `
+                <div class="summary-item">
+                    <h3>${eventName}</h3>
+                    <p><strong>参加者:</strong> ${data.lastName} ${data.firstName} 様</p>
+                    <p><strong>メールアドレス:</strong> ${data.email}</p>
+                </div>
+            `;
+            
+            if (data.memberType) {
+                const memberTypeText = {
+                    'regular': '一般会員',
+                    'student': '学生会員',
+                    'member': '会員',
+                    'non-member': '非会員'
+                }[data.memberType] || data.memberType;
+                html += `<p><strong>会員区分:</strong> ${memberTypeText}</p>`;
+            }
+            
+            if (data.paymentMethod) {
+                const paymentText = {
+                    'credit': 'クレジットカード',
+                    'bank': '銀行振込',
+                    'onsite': '現地決済'
+                }[data.paymentMethod] || data.paymentMethod;
+                html += `<p><strong>支払い方法:</strong> ${paymentText}</p>`;
+            }
+            
+            summaryDiv.innerHTML = html;
+            document.getElementById('finalAmount').textContent = amount;
+        }
+        
+        function showPaymentMethod(method) {
+            // すべてのセクションを非表示
+            document.querySelectorAll('.payment-method-section').forEach(section => {
+                section.style.display = 'none';
+            });
+            
+            // 選択された支払い方法のセクションを表示
+            if (method === 'credit') {
+                document.getElementById('creditCardSection').style.display = 'block';
+            } else if (method === 'bank') {
+                document.getElementById('bankTransferSection').style.display = 'block';
+            } else if (method === 'onsite') {
+                document.getElementById('onsitePaymentSection').style.display = 'block';
+            }
+        }
+        
+        function processPayment(data, eventType, amount) {
+            const paymentMethod = data.paymentMethod;
+            
+            if (paymentMethod === 'credit') {
+                // クレジットカード決済の検証
+                const cardNumber = document.getElementById('cardNumber').value;
+                const expiryDate = document.getElementById('expiryDate').value;
+                const cvv = document.getElementById('cvv').value;
+                const cardName = document.getElementById('cardName').value;
+                
+                if (!cardNumber || !expiryDate || !cvv || !cardName) {
+                    alert('クレジットカード情報をすべて入力してください。');
+                    return;
+                }
+            }
+            
+            // 決済処理のシミュレーション
+            document.getElementById('paymentForm').style.display = 'none';
+            
+            setTimeout(() => {
+                // 登録番号の生成
+                const registrationNumber = 'REG' + Date.now().toString().slice(-8);
+                document.getElementById('registrationNumber').textContent = registrationNumber;
+                
+                // 完了画面の表示
+                document.getElementById('paymentComplete').style.display = 'block';
+                
+                // セッションデータのクリア
+                sessionStorage.removeItem('conferenceRegistration');
+                sessionStorage.removeItem('seminarRegistration');
+                sessionStorage.removeItem('totalAmount');
+                
+                // ページトップにスクロール
+                window.scrollTo(0, 0);
+            }, 2000);
+        }
+        
+        // カード番号のフォーマット
+        document.getElementById('cardNumber')?.addEventListener('input', function(e) {
+            let value = e.target.value.replace(/\s/g, '');
+            let formattedValue = value.replace(/(.{4})/g, '$1 ').trim();
+            if (formattedValue.length > 19) formattedValue = formattedValue.slice(0, 19);
+            e.target.value = formattedValue;
+        });
+        
+        // 有効期限のフォーマット
+        document.getElementById('expiryDate')?.addEventListener('input', function(e) {
+            let value = e.target.value.replace(/\D/g, '');
+            if (value.length >= 2) {
+                value = value.slice(0, 2) + '/' + value.slice(2, 4);
+            }
+            e.target.value = value;
+        });
+    </script>
+</body>
+</html>

--- a/registration/seminar.html
+++ b/registration/seminar.html
@@ -1,0 +1,213 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>夏季セミナー参加登録 - テスト学会</title>
+    <link rel="stylesheet" href="../css/style.css">
+</head>
+<body>
+    <header>
+        <nav class="navbar">
+            <div class="nav-container">
+                <h1 class="nav-logo">テスト学会</h1>
+                <ul class="nav-menu">
+                    <li class="nav-item">
+                        <a href="../index.html" class="nav-link">ホーム</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="../about.html" class="nav-link">学会について</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="../news/index.html" class="nav-link">お知らせ</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="../events/index.html" class="nav-link">イベント</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="index.html" class="nav-link active">参加登録</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="../abstracts/index.html" class="nav-link">抄録投稿</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="../members/index.html" class="nav-link">参加者専用</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="../contact.html" class="nav-link">お問い合わせ</a>
+                    </li>
+                </ul>
+                <div class="hamburger">
+                    <span class="bar"></span>
+                    <span class="bar"></span>
+                    <span class="bar"></span>
+                </div>
+            </div>
+        </nav>
+    </header>
+
+    <div class="page-header">
+        <div class="container">
+            <h1>夏季セミナー2025 参加登録</h1>
+            <p>2025年6月15日（土） 13:00-17:00 東京国際会議場</p>
+        </div>
+    </div>
+
+    <main class="content">
+        <div class="container">
+            <div class="back-link">
+                <a href="index.html">← 参加登録一覧に戻る</a>
+            </div>
+
+            <form class="registration-form" id="seminarForm">
+                <div class="form-section">
+                    <h2>参加者情報</h2>
+                    
+                    <div class="form-row">
+                        <div class="form-group">
+                            <label for="lastName">姓 *</label>
+                            <input type="text" id="lastName" name="lastName" required>
+                        </div>
+                        <div class="form-group">
+                            <label for="firstName">名 *</label>
+                            <input type="text" id="firstName" name="firstName" required>
+                        </div>
+                    </div>
+
+                    <div class="form-row">
+                        <div class="form-group">
+                            <label for="lastNameKana">姓（カナ） *</label>
+                            <input type="text" id="lastNameKana" name="lastNameKana" required>
+                        </div>
+                        <div class="form-group">
+                            <label for="firstNameKana">名（カナ） *</label>
+                            <input type="text" id="firstNameKana" name="firstNameKana" required>
+                        </div>
+                    </div>
+
+                    <div class="form-group">
+                        <label for="email">メールアドレス *</label>
+                        <input type="email" id="email" name="email" required>
+                    </div>
+
+                    <div class="form-group">
+                        <label for="phone">電話番号 *</label>
+                        <input type="tel" id="phone" name="phone" required>
+                    </div>
+
+                    <div class="form-group">
+                        <label for="affiliation">所属機関</label>
+                        <input type="text" id="affiliation" name="affiliation">
+                    </div>
+                </div>
+
+                <div class="form-section">
+                    <h2>参加区分・参加費</h2>
+                    
+                    <div class="form-group">
+                        <label>会員区分 *</label>
+                        <div class="radio-group">
+                            <label class="radio-label">
+                                <input type="radio" name="memberType" value="member" required>
+                                <span class="radio-text">会員（3,000円）</span>
+                            </label>
+                            <label class="radio-label">
+                                <input type="radio" name="memberType" value="non-member" required>
+                                <span class="radio-text">非会員（5,000円）</span>
+                            </label>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="form-section">
+                    <h2>支払い方法</h2>
+                    
+                    <div class="form-group">
+                        <label>お支払い方法 *</label>
+                        <div class="radio-group">
+                            <label class="radio-label">
+                                <input type="radio" name="paymentMethod" value="credit" required>
+                                <span class="radio-text">クレジットカード（即時決済）</span>
+                            </label>
+                            <label class="radio-label">
+                                <input type="radio" name="paymentMethod" value="bank" required>
+                                <span class="radio-text">銀行振込（請求書発行）</span>
+                            </label>
+                            <label class="radio-label">
+                                <input type="radio" name="paymentMethod" value="onsite" required>
+                                <span class="radio-text">現地決済</span>
+                            </label>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="form-section">
+                    <h2>特記事項</h2>
+                    
+                    <div class="form-group">
+                        <label for="specialRequests">アクセシビリティ等のご要望</label>
+                        <textarea id="specialRequests" name="specialRequests" rows="3" placeholder="車椅子でのアクセス、その他のご要望があればお書きください"></textarea>
+                    </div>
+                </div>
+
+                <div class="total-amount">
+                    <h3>合計金額: <span id="totalAmount">0</span>円</h3>
+                </div>
+
+                <div class="form-actions">
+                    <button type="button" class="btn btn-secondary" onclick="window.history.back()">戻る</button>
+                    <button type="submit" class="btn btn-primary">決済画面へ進む</button>
+                </div>
+            </form>
+        </div>
+    </main>
+
+    <footer>
+        <div class="container">
+            <p>&copy; 2025 テスト学会. All rights reserved.</p>
+        </div>
+    </footer>
+
+    <script src="../js/script.js"></script>
+    <script>
+        // 金額計算
+        function calculateTotal() {
+            let total = 0;
+            
+            const memberType = document.querySelector('input[name="memberType"]:checked');
+            if (memberType) {
+                switch(memberType.value) {
+                    case 'member': total += 3000; break;
+                    case 'non-member': total += 5000; break;
+                }
+            }
+            
+            document.getElementById('totalAmount').textContent = total.toLocaleString();
+        }
+        
+        // イベントリスナー
+        document.querySelectorAll('input[name="memberType"]').forEach(input => {
+            input.addEventListener('change', calculateTotal);
+        });
+        
+        // フォーム送信
+        document.getElementById('seminarForm').addEventListener('submit', function(e) {
+            e.preventDefault();
+            
+            const formData = new FormData(this);
+            const data = {};
+            for (let [key, value] of formData.entries()) {
+                data[key] = value;
+            }
+            
+            sessionStorage.setItem('seminarRegistration', JSON.stringify(data));
+            sessionStorage.setItem('totalAmount', document.getElementById('totalAmount').textContent);
+            
+            window.location.href = 'payment.html?event=seminar';
+        });
+        
+        // 初期計算
+        calculateTotal();
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## 概要
学会ホームページに決済・抄録投稿・参加者限定ページを追加しました。

## 新機能
- 🔗 **参加登録・決済システム** - 学術会議・セミナー登録フォーム、金額自動計算、決済処理
- 📝 **抄録投稿システム** - 口頭・ポスター発表対応、文字数制限、下書き保存
- 🔒 **参加者限定エリア** - ログイン認証、ダッシュボード、配布資料ダウンロード

## 技術改善
- レスポンシブデザイン対応
- 8項目対応ナビゲーション更新
- JavaScriptによる動的機能追加
- 包括的CSS追加

## デモログイン
REG12345678 / demo@test-society.jp

## ファイル構成
```
/
├── registration/ (参加登録システム)
├── abstracts/ (抄録投稿システム)
├── members/ (参加者限定エリア)
└── 既存ページのナビゲーション更新
```

Generated with [Claude Code](https://claude.ai/code)